### PR TITLE
chore: use renovate to auto update deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["config:base"],
+  "additionalBranchPrefix": "chore/",
+  "reviewers": [
+    "qwqcode",
+    "kecrily"
+  ]
+}


### PR DESCRIPTION
- [ ] Should enable [GitHub App](https://github.com/apps/renovate) after merge

---

It should automatically use the Angular Conventional Commit Style if it can detect it. And this should only be a temporary alternative for [pnpm if GitHub's own dependabot doesn't support it yet](https://github.com/dependabot/dependabot-core/issues/1736), but if it's doing well just let it keep doing it