### PR TITLE
fix: sidebar navigation sorting

### DIFF
--- a/ui/packages/artalk-sidebar/src/pages/comments.vue
+++ b/ui/packages/artalk-sidebar/src/pages/comments.vue
@@ -25,11 +25,11 @@ onMounted(() => {
     }, 'admin_all')
   } else {
     nav.updateTabs({
-      mentions: t('mentions'),
       all: t('all'),
+      mentions: t('mentions'),
       mine: t('mine'),
       pending: t('pending'),
-    }, 'mentions')
+    }, 'all')
   }
 
   watch(curtTab, (curtTab) => {


### PR DESCRIPTION
This pr does one thing: adjusts the order of items in the sidebar navigation bar for non-admin users, and shows all comments by default

|Before|Now|
|:----|:----|
| <ul><li>Mentions (default)</li><li>All</li><li>Mine</li><li>Pending</li></ui> | <ul><li>All (default)</li><li>Mentions</li><li>Mine</li><li>Pending</li></ui> |