### PR TITLE
feat: simple cache gc

### DIFF
--- a/internal/cache/simple_cache/cache_test.go
+++ b/internal/cache/simple_cache/cache_test.go
@@ -61,11 +61,33 @@ func TestCache(t *testing.T) {
 		}
 	})
 
-	t.Run("GC", func(t *testing.T) {
-		cache := New()
+	t.Run("GC thold reached", func(t *testing.T) {
+		cache := NewWithGCThold(1)
 		cache.Set("key", "value", 1*time.Millisecond)
 		time.Sleep(2 * time.Millisecond)
-		cache.GC()
+		cache.GC(false)
+		_, ok := cache.Get("key")
+		if ok {
+			t.Error("cache should be expired")
+		}
+	})
+
+	t.Run("GC thold not reached", func(t *testing.T) {
+		cache := NewWithGCThold(2)
+		cache.Set("key", "value", 1*time.Millisecond)
+		time.Sleep(2 * time.Millisecond)
+		cache.GC(false)
+		len := cache.len.Load()
+		if len != 1 {
+			t.Errorf("cache length should be 1, but got %d", len)
+		}
+	})
+
+	t.Run("GC thold not reached but force GC", func(t *testing.T) {
+		cache := NewWithGCThold(2)
+		cache.Set("key", "value", 1*time.Millisecond)
+		time.Sleep(2 * time.Millisecond)
+		cache.GC(true)
 		_, ok := cache.Get("key")
 		if ok {
 			t.Error("cache should be expired")

--- a/internal/cache/simple_cache/cache_test.go
+++ b/internal/cache/simple_cache/cache_test.go
@@ -72,6 +72,16 @@ func TestCache(t *testing.T) {
 		}
 	})
 
+	t.Run("GC not expired", func(t *testing.T) {
+		cache := NewWithGCThold(1)
+		cache.Set("key", "value")
+		cache.GC(false)
+		_, ok := cache.Get("key")
+		if !ok {
+			t.Error("cache should not be expired")
+		}
+	})
+
 	t.Run("GC thold not reached", func(t *testing.T) {
 		cache := NewWithGCThold(2)
 		cache.Set("key", "value", 1*time.Millisecond)

--- a/internal/cache/simple_cache/cache_test.go
+++ b/internal/cache/simple_cache/cache_test.go
@@ -60,4 +60,15 @@ func TestCache(t *testing.T) {
 			t.Error("cache should be deleted")
 		}
 	})
+
+	t.Run("GC", func(t *testing.T) {
+		cache := New()
+		cache.Set("key", "value", 1*time.Millisecond)
+		time.Sleep(2 * time.Millisecond)
+		cache.GC()
+		_, ok := cache.Get("key")
+		if ok {
+			t.Error("cache should be expired")
+		}
+	})
 }


### PR DESCRIPTION
A new `GC()` method has been added to the `Cache` struct, which performs garbage collection by deleting expired entries from the cache.