### PR TITLE
fix(ui): fix static method export issue in JS module

### DIFF
--- a/docs/develop/fe-api.md
+++ b/docs/develop/fe-api.md
@@ -12,7 +12,7 @@ npm install artalk
 
 ## 创建实例 `init`
 
-`Artalk.init` 函数和 `new Artalk` 等价，调用该函数将创建并得到一个 Artalk 的实例化对象，可用于后续操作。
+调用该函数将创建并得到一个 Artalk 的实例化对象，可用于后续操作。
 
 ```js
 import Artalk from 'artalk'

--- a/ui/packages/artalk/src/artalk.ts
+++ b/ui/packages/artalk/src/artalk.ts
@@ -3,7 +3,6 @@ import './style/main.scss'
 import type { ArtalkConfig, EventPayloadMap, ArtalkPlugin, ContextApi } from '~/types'
 import type { EventHandler } from './lib/event-manager'
 import ConcreteContext from './context'
-import defaults from './defaults'
 import { handelCustomConf, convertApiOptions } from './config'
 import Services from './service'
 import { DefaultPlugins } from './plugins'
@@ -89,9 +88,6 @@ export default class Artalk {
   // ===========================
   //       Static Members
   // ===========================
-
-  /** Default Configs */
-  public static readonly defaults: ArtalkConfig = defaults
 
   /** Init Artalk */
   public static init(conf: Partial<ArtalkConfig>): Artalk {

--- a/ui/packages/artalk/src/main.ts
+++ b/ui/packages/artalk/src/main.ts
@@ -3,3 +3,12 @@ import * as ArtalkType from '../types'
 
 export { ArtalkType }
 export default Artalk
+
+// Expose the static methods from the Artalk class
+// because direct export of static methods is not supported
+// for adapting to different environments like CommonJS and browser IIFE
+// for example, we can use `Artalk.init()` rather than `Artalk.default.init()`
+// therefore, we need to manually expose the static methods in the Artalk class.
+export const init = Artalk.init
+export const use = Artalk.use
+export const loadCountWidget = Artalk.loadCountWidget

--- a/ui/packages/artalk/vite.config.ts
+++ b/ui/packages/artalk/vite.config.ts
@@ -18,7 +18,10 @@ export default Utils.mergeDeep(baseConf, defineConfig({
     rollupOptions: {
       output: {
         assetFileNames: (assetInfo) => (/\.css$/.test(assetInfo.name || '') ? "Artalk.css" : "[name].[ext]"),
-        exports: 'named'
+
+        // @see https://github.com/rollup/rollup/issues/587
+        //  and https://github.com/rollup/rollup/pull/631/files
+        exports: 'named',
       }
     }
   },


### PR DESCRIPTION
We've implemented changes in `main.ts`, the entry point of the JS module.

As direct export of static methods isn't supported, we've adapted the code to accommodate various environments such as CommonJS and browser IIFE. For instance, now we can utilize `Artalk.init()` instead of `Artalk.default.init()`. Consequently, it's necessary to manually expose the static methods within the Artalk class.

https://github.com/rollup/rollup/issues/587

https://github.com/rollup/rollup/pull/631/files