### PR TITLE
refactor(ui/conf): better handling of mutable config

### DIFF
--- a/ui/artalk/src/artalk.ts
+++ b/ui/artalk/src/artalk.ts
@@ -9,8 +9,6 @@ import { DefaultPlugins } from './plugins'
 import * as Stat from './plugins/stat'
 import Api from './api'
 import type { TInjectedServices } from './service'
-import * as Utils from "./lib/utils";
-import Defaults from "./defaults";
 
 /** Global Plugins for all instances */
 const GlobalPlugins: ArtalkPlugin[] = [ ...DefaultPlugins ]
@@ -21,20 +19,17 @@ const GlobalPlugins: ArtalkPlugin[] = [ ...DefaultPlugins ]
  * @see https://artalk.js.org
  */
 export default class Artalk {
-  public conf!: ArtalkConfig
   public ctx!: ContextApi
-  public $root!: HTMLElement
 
   /** Plugins */
   protected plugins: ArtalkPlugin[] = [ ...GlobalPlugins ]
 
   constructor(conf: Partial<ArtalkConfig>) {
     // Init Config
-    this.conf = handelCustomConf(Utils.mergeDeep(Utils.mergeDeep({}, Defaults), conf))
-    if (this.conf.el instanceof HTMLElement) this.$root = this.conf.el
+    const handledConf = handelCustomConf(conf, true)
 
     // Init Context
-    this.ctx = new Context(this.conf, this.$root)
+    this.ctx = new Context(handledConf)
 
     // Init Services
     Object.entries(Services).forEach(([name, initService]) => {
@@ -51,6 +46,16 @@ export default class Artalk {
     this.ctx.trigger('inited')
   }
 
+  /** Get the config of Artalk */
+  public getConf() {
+    return this.ctx.getConf()
+  }
+
+  /** Get the root element of Artalk */
+  public getEl() {
+    return this.ctx.$root
+  }
+
   /** Update config of Artalk */
   public update(conf: Partial<ArtalkConfig>) {
     this.ctx.updateConf(conf)
@@ -65,7 +70,7 @@ export default class Artalk {
   /** Destroy instance of Artalk */
   public destroy() {
     this.ctx.trigger('destroy')
-    this.$root.remove()
+    this.ctx.$root.remove()
   }
 
   /** Add an event listener */
@@ -105,7 +110,7 @@ export default class Artalk {
 
   /** Load count widget */
   public static loadCountWidget(c: Partial<ArtalkConfig>) {
-    const conf = handelCustomConf(c)
+    const conf = handelCustomConf(c, true)
 
     Stat.initCountWidget({
       getApi: () => new Api(convertApiOptions(conf)),
@@ -115,4 +120,14 @@ export default class Artalk {
       pvAdd: false
     })
   }
+
+  // ===========================
+  //         Deprecated
+  // ===========================
+
+  /** @deprecated Please use `getEl()` instead */
+  public get $root() { return this.ctx.$root }
+
+  /** @description Please use `getConf()` instead */
+  public get conf() { return this.ctx.getConf() }
 }

--- a/ui/artalk/src/artalk.ts
+++ b/ui/artalk/src/artalk.ts
@@ -9,6 +9,8 @@ import { DefaultPlugins } from './plugins'
 import * as Stat from './plugins/stat'
 import Api from './api'
 import type { TInjectedServices } from './service'
+import * as Utils from "./lib/utils";
+import Defaults from "./defaults";
 
 /** Global Plugins for all instances */
 const GlobalPlugins: ArtalkPlugin[] = [ ...DefaultPlugins ]
@@ -28,7 +30,7 @@ export default class Artalk {
 
   constructor(conf: Partial<ArtalkConfig>) {
     // Init Config
-    this.conf = handelCustomConf(conf)
+    this.conf = handelCustomConf(Utils.mergeDeep(Utils.mergeDeep({}, Defaults), conf))
     if (this.conf.el instanceof HTMLElement) this.$root = this.conf.el
 
     // Init Context

--- a/ui/artalk/src/config.ts
+++ b/ui/artalk/src/config.ts
@@ -11,7 +11,7 @@ import Defaults from './defaults'
  */
 export function handelCustomConf(customConf: Partial<ArtalkConfig>): ArtalkConfig {
   // 合并默认配置
-  const conf: ArtalkConfig = Utils.mergeDeep({ ...Defaults }, customConf)
+  const conf: ArtalkConfig = Utils.mergeDeep({}, customConf)
 
   // TODO the type of el options may HTMLElement, use it directly instead of from mergeDeep
   if (customConf.el) conf.el = customConf.el

--- a/ui/artalk/src/config.ts
+++ b/ui/artalk/src/config.ts
@@ -1,27 +1,20 @@
 import type { ArtalkConfig, ContextApi } from '~/types'
 import type { ApiOptions } from './api/_options'
-import * as Utils from './lib/utils'
+import { mergeDeep } from './lib/merge-deep'
 import Defaults from './defaults'
 
 
 /**
- * Merges the user custom config with the default config
-*
-* @param customConf - The custom config object which is provided by the user
-* @param mergeDefaults - If `true`, the default config will be merged into the custom config
-* @returns The config for Artalk instance creation
-*/
-export function handelCustomConf(customConf: Partial<ArtalkConfig>, mergeDefaults?: true): ArtalkConfig
-export function handelCustomConf(customConf: Partial<ArtalkConfig>, mergeDefaults: false): Partial<ArtalkConfig>
-export function handelCustomConf(customConf: Partial<ArtalkConfig>, mergeDefaults = true) {
+ * Handle the custom config which is provided by the user
+ *
+ * @param customConf - The custom config object which is provided by the user
+ * @returns The config for Artalk instance creation
+ */
+export function handelCustomConf(customConf: Partial<ArtalkConfig>, mergeDefault: true): ArtalkConfig
+export function handelCustomConf(customConf: Partial<ArtalkConfig>, mergeDefault?: false): Partial<ArtalkConfig>
+export function handelCustomConf(customConf: Partial<ArtalkConfig>, mergeDefault = false) {
   // 合并默认配置
-  let conf: ArtalkConfig | Partial<ArtalkConfig> = { ...customConf }
-  if (mergeDefaults) {
-    conf = Utils.mergeDeep({ ...Defaults }, customConf)
-  }
-
-  // TODO the type of el options may HTMLElement, use it directly instead of from mergeDeep
-  if (customConf.el) conf.el = customConf.el
+  const conf: Partial<ArtalkConfig> = mergeDefault ? mergeDeep(Defaults, customConf) : customConf
 
   // 绑定元素
   if (typeof conf.el === 'string' && !!conf.el) {

--- a/ui/artalk/src/config.ts
+++ b/ui/artalk/src/config.ts
@@ -3,15 +3,22 @@ import type { ApiOptions } from './api/_options'
 import * as Utils from './lib/utils'
 import Defaults from './defaults'
 
+
 /**
  * Merges the user custom config with the default config
- *
- * @param customConf - The custom config object which is provided by the user
- * @returns The config for Artalk instance creation
- */
-export function handelCustomConf(customConf: Partial<ArtalkConfig>): ArtalkConfig {
+*
+* @param customConf - The custom config object which is provided by the user
+* @param mergeDefaults - If `true`, the default config will be merged into the custom config
+* @returns The config for Artalk instance creation
+*/
+export function handelCustomConf(customConf: Partial<ArtalkConfig>, mergeDefaults?: true): ArtalkConfig
+export function handelCustomConf(customConf: Partial<ArtalkConfig>, mergeDefaults: false): Partial<ArtalkConfig>
+export function handelCustomConf(customConf: Partial<ArtalkConfig>, mergeDefaults = true) {
   // 合并默认配置
-  const conf: ArtalkConfig = Utils.mergeDeep({}, customConf)
+  let conf: ArtalkConfig | Partial<ArtalkConfig> = { ...customConf }
+  if (mergeDefaults) {
+    conf = Utils.mergeDeep({ ...Defaults }, customConf)
+  }
 
   // TODO the type of el options may HTMLElement, use it directly instead of from mergeDeep
   if (customConf.el) conf.el = customConf.el
@@ -29,7 +36,9 @@ export function handelCustomConf(customConf: Partial<ArtalkConfig>): ArtalkConfi
   }
 
   // 服务器配置
-  conf.server = conf.server.replace(/\/$/, '').replace(/\/api\/?$/, '')
+  if (conf.server) {
+    conf.server = conf.server.replace(/\/$/, '').replace(/\/api\/?$/, '')
+  }
 
   // 默认 pageKey
   if (!conf.pageKey) {

--- a/ui/artalk/src/context.ts
+++ b/ui/artalk/src/context.ts
@@ -134,7 +134,7 @@ class Context implements ContextApi {
   }
 
   public updateConf(nConf: Partial<ArtalkConfig>): void {
-    this.conf = Utils.mergeDeep(this.conf, handelCustomConf(nConf))
+    this.conf = handelCustomConf(Utils.mergeDeep(this.conf, nConf))
     this.events.trigger('conf-loaded', this.conf)
   }
 

--- a/ui/artalk/src/context.ts
+++ b/ui/artalk/src/context.ts
@@ -2,8 +2,8 @@ import type { ArtalkConfig, CommentData, ListFetchParams, ContextApi, EventPaylo
 import type { TInjectedServices } from './service'
 import Api from './api'
 
-import * as Utils from './lib/utils'
 import * as marked from './lib/marked'
+import { mergeDeep } from './lib/merge-deep'
 import { CheckerCaptchaPayload, CheckerPayload } from './components/checker'
 
 import { DataManager } from './data'
@@ -27,10 +27,10 @@ class Context implements ContextApi {
   /* Event Manager */
   private events = new EventManager<EventPayloadMap>()
 
-  public constructor(conf: ArtalkConfig, $root?: HTMLElement) {
+  public constructor(conf: ArtalkConfig) {
     this.conf = conf
 
-    this.$root = $root || document.createElement('div')
+    this.$root = (conf.el instanceof Element) ? conf.el : document.createElement('div')
     this.$root.classList.add('artalk')
     this.$root.innerHTML = ''
 
@@ -134,8 +134,12 @@ class Context implements ContextApi {
   }
 
   public updateConf(nConf: Partial<ArtalkConfig>): void {
-    this.conf = handelCustomConf(Utils.mergeDeep(this.conf, nConf))
+    this.conf = mergeDeep(this.conf, handelCustomConf(nConf, false))
     this.events.trigger('conf-loaded', this.conf)
+  }
+
+  public getConf(): ArtalkConfig {
+    return this.conf
   }
 
   public getMarked() {

--- a/ui/artalk/src/context.ts
+++ b/ui/artalk/src/context.ts
@@ -30,7 +30,7 @@ class Context implements ContextApi {
   public constructor(conf: ArtalkConfig) {
     this.conf = conf
 
-    this.$root = (conf.el instanceof Element) ? conf.el : document.createElement('div')
+    this.$root = conf.el as HTMLElement
     this.$root.classList.add('artalk')
     this.$root.innerHTML = ''
 

--- a/ui/artalk/src/lib/merge-deep.test.ts
+++ b/ui/artalk/src/lib/merge-deep.test.ts
@@ -43,3 +43,23 @@ describe('Prevent in-place modify: mergeDeep(a, b)', () => {
     expect(b).toEqual({ a: 1, arr: [1, 2, 3] })
   })
 })
+
+describe('Merge special types', () => {
+  const testItem = (name: string, val: any) => {
+    it(name, () => {
+      expect(mergeDeep({ a: val }, { b: val })).toEqual({ a: val, b: val })
+    })
+  }
+
+  const dom = document.createElement('div')
+  testItem('should can keep dom, not deep recursion', dom)
+
+  const fn = () => {}
+  testItem('should can keep function', fn)
+
+  const date = new Date()
+  testItem('should can keep date', date)
+
+  const reg = /abc/
+  testItem('should can keep regex', reg)
+})

--- a/ui/artalk/src/lib/merge-deep.test.ts
+++ b/ui/artalk/src/lib/merge-deep.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { mergeDeep } from './merge-deep'
+
+describe('Normal operations', () => {
+  it('should merge objects (1 level)', () => {
+    expect(mergeDeep({ a: 1 }, { b: 2 })).toEqual({ a: 1, b: 2 })
+    expect(mergeDeep({ a: 1 }, { a: 2 })).toEqual({ a: 2 })
+  })
+
+  it('should merge objects (2 levels)', () => {
+    expect(mergeDeep({ a: { b: 1 } }, { a: { c: 2 } })).toEqual({ a: { b: 1, c: 2 } })
+    expect(mergeDeep({ a: { b: 1 } }, { a: { b: 2 } })).toEqual({ a: { b: 2 } })
+  })
+
+  it('should merge objects (3 levels)', () => {
+    expect(mergeDeep({ a: { b: { c: 1 } } }, { a: { b: { d: 2 } } })).toEqual({ a: { b: { c: 1, d: 2 } } })
+    expect(mergeDeep({ a: { b: { c: 1 } } }, { a: { b: { c: 2 } } })).toEqual({ a: { b: { c: 2 } } })
+  })
+})
+
+describe('Array merge', () => {
+  it('should merge arrays (1 level)', () => {
+    expect(mergeDeep({ a: [1] }, { a: [2] })).toEqual({ a: [1, 2] })
+  })
+  it('should merge arrays (2 levels)', () => {
+    expect(mergeDeep({ a: { b: [1] } }, { a: { b: [2] } })).toEqual({ a: { b: [1, 2] } })
+  })
+  it('should merge arrays (3 levels)', () => {
+    expect(mergeDeep({ a: { b: { c: [1] } } }, { a: { b: { c: [2] } } })).toEqual({ a: { b: { c: [1, 2] } } })
+  })
+})
+
+describe('Prevent in-place modify: mergeDeep(a, b)', () => {
+  it('should not modify a', () => {
+    const a: any = { a: 1, arr: [1, 2, 3] }
+    mergeDeep(a, { a: 2, arr: [4, 5, 6] })
+    expect(a).toEqual({ a: 1, arr: [1, 2, 3] })
+  })
+
+  it('should not modify b', () => {
+    const b: any = { a: 1, arr: [1, 2, 3] }
+    mergeDeep({ a: 2, arr: [4, 5, 6] }, b)
+    expect(b).toEqual({ a: 1, arr: [1, 2, 3] })
+  })
+})

--- a/ui/artalk/src/lib/merge-deep.ts
+++ b/ui/artalk/src/lib/merge-deep.ts
@@ -1,0 +1,27 @@
+/**
+ * Performs a deep merge of objects and returns new object.
+ * Does not modify objects (immutable) and merges arrays via concatenation.
+ *
+ * @param objects - Objects to merge
+ * @returns New object with merged key/values
+ */
+export function mergeDeep<T>(...objects: any[]): T {
+  const isObject = (obj: any) => obj && typeof obj === "object";
+
+  return objects.reduce((prev, obj) => {
+    Object.keys(obj ?? {}).forEach((key) => {
+      const pVal = prev[key]
+      const oVal = obj[key]
+
+      if (Array.isArray(pVal) && Array.isArray(oVal)) {
+        prev[key] = pVal.concat(...oVal)
+      } else if (isObject(pVal) && isObject(oVal)) {
+        prev[key] = mergeDeep(pVal, oVal)
+      } else {
+        prev[key] = oVal
+      }
+    })
+
+    return prev
+  }, {})
+}

--- a/ui/artalk/src/lib/merge-deep.ts
+++ b/ui/artalk/src/lib/merge-deep.ts
@@ -6,10 +6,15 @@
  * @returns New object with merged key/values
  */
 export function mergeDeep<T>(...objects: any[]): T {
-  const isObject = (obj: any) => obj && typeof obj === "object";
+  const isObject = (obj: any) => obj && typeof obj === "object" && obj.constructor === Object;
 
   return objects.reduce((prev, obj) => {
     Object.keys(obj ?? {}).forEach((key) => {
+      // Avoid prototype pollution
+      if (key === "__proto__" || key === "constructor" || key === "prototype") {
+        return
+      }
+
       const pVal = prev[key]
       const oVal = obj[key]
 

--- a/ui/artalk/src/lib/utils.ts
+++ b/ui/artalk/src/lib/utils.ts
@@ -204,33 +204,3 @@ export function getURLBasedOnApi(opts: { base: string, path: string }) {
 export function getURLBasedOn(baseURL: string, path: string) {
   return `${baseURL.replace(/\/$/, '')}/${path.replace(/^\//, '')}`
 }
-
-/**
- * Performs a deep merge of `source` into `target`.
- * Mutates `target` only but not its objects and arrays.
- *
- * @author inspired by [jhildenbiddle](https://stackoverflow.com/a/48218209).
- * @link https://gist.github.com/ahtcx/0cd94e62691f539160b32ecda18af3d6
- */
-export function mergeDeep(target: any, source: any) {
-  const isObject = (obj: any) => obj && typeof obj === 'object'
-
-  if (!isObject(target) || !isObject(source)) {
-    return source
-  }
-
-  Object.keys(source).forEach(key => {
-    const targetValue = target[key]
-    const sourceValue = source[key]
-
-    if (Array.isArray(targetValue) && Array.isArray(sourceValue)) {
-      target[key] = targetValue.concat(sourceValue)
-    } else if (isObject(targetValue) && isObject(sourceValue)) {
-      target[key] = mergeDeep({ ...targetValue}, sourceValue)
-    } else {
-      target[key] = sourceValue
-    }
-  })
-
-  return target
-}

--- a/ui/artalk/src/plugins/conf-remoter.ts
+++ b/ui/artalk/src/plugins/conf-remoter.ts
@@ -4,6 +4,11 @@ import { showErrorDialog } from '../components/error-dialog'
 
 export const ConfRemoter: ArtalkPlugin = (ctx) => {
   ctx.on('inited', () => {
+    if (ctx.conf.immediateFetch === false) return
+    ctx.trigger('conf-fetch')
+  })
+
+  ctx.on('conf-fetch', () => {
     loadConf(ctx)
   })
 }

--- a/ui/artalk/tests/setup.ts
+++ b/ui/artalk/tests/setup.ts
@@ -1,0 +1,16 @@
+import { vi } from 'vitest'
+
+// @see https://github.com/vitest-dev/vitest/issues/821
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(), // deprecated
+    removeListener: vi.fn(), // deprecated
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+})

--- a/ui/artalk/tests/ui-api.test.ts
+++ b/ui/artalk/tests/ui-api.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest'
+import Artalk from '@/artalk'
+
+const InitConf = {
+  pageKey: '/unit_test_page.html?test=1',
+  server: 'http://localhost:3000/api',
+  site: 'Unit Test Page',
+  darkMode: true,
+}
+
+const RemoteConf = {
+  darkMode: false, // simulate response `false`, but the final should still be `true`, cannot override this
+  gravatar: { mirror: 'https://test.avatar.com/unit_test', params: 'test=123' }
+}
+
+const ContainerID = 'artalk-container'
+
+beforeAll(() => {
+  // mock fetch
+  global.fetch = vi.fn().mockImplementation((url: string, init: RequestInit) => Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => {
+      const resp = {
+        success: true,
+        data: {}
+      }
+      const map = {
+        '/api/conf': {
+          frontend_conf: RemoteConf,
+          version: {},
+        },
+        '/api/stat': { '/': 0 },
+        '/api/pv': { pv: 2 },
+        '/api/get': {
+          comments: [],
+          total: 0,
+          total_roots: 0,
+          page: { id: 4, admin_only: false, key: '/', url: '/', title: 'Artalk DEMO', site_name: 'ArtalkDocs', vote_up: 0, vote_down: 0, pv: 1 },
+          unread: [],
+          unread_count: 0,
+          conf: { frontend_conf: {}, version: {} },
+        }
+      }
+
+      Object.entries(map).forEach(([k, v]) => {
+        if (url.endsWith(k)) resp.data = v
+      })
+
+      return Promise.resolve(resp)
+    }
+  })) as any
+})
+
+describe('Artalk instance', () => {
+  it('should be a class', () => {
+    expect(Artalk).toBeInstanceOf(Function)
+  })
+
+  let artalk: Artalk
+
+  it('create an instance (artalk.init)', () => {
+    const el = document.createElement('div')
+    el.setAttribute('id', ContainerID)
+    document.body.appendChild(el)
+
+    artalk = Artalk.init({
+      el,
+      pageKey: InitConf.pageKey,
+      server: InitConf.server,
+      site: InitConf.site,
+      darkMode: InitConf.darkMode,
+
+      immediateFetch: false,  // for testing
+    })
+
+    expect(artalk).toBeInstanceOf(Artalk)
+  })
+
+  it('should have correct config (artalk.getConf, artalk.getEl)', () => {
+    const conf = artalk.getConf()
+    expect(conf.pageKey).toBe(InitConf.pageKey)
+    expect(conf.server).toBe(InitConf.server.replace('/api', ''))
+    expect(conf.site).toBe(InitConf.site)
+    expect(conf.darkMode).toBe(InitConf.darkMode)
+
+    expect(artalk.getEl().classList.contains('atk-dark-mode')).toBe(true)
+  })
+
+  it('should can listen to events and the conf-remoter works (artalk.trigger, artalk.on, conf-remoter)', async () => {
+    artalk.trigger('conf-fetch')
+
+    const fn = vi.fn()
+
+    await new Promise(resolve => {
+      artalk.on('conf-loaded', (conf) => {
+        resolve(null)
+        fn()
+      })
+    })
+
+    expect(fn).toBeCalledTimes(1)
+
+    const conf = artalk.getConf()
+    expect(conf.darkMode, "the darkMode is unmodifiable, should still false").toBe(true)
+    expect(conf.gravatar, "the gravatar should be modified").toEqual(RemoteConf.gravatar)
+  }, {
+    timeout: 1000
+  })
+
+  it('should can update config (artalk.update)', () => {
+    const Placeholder = 'Test Placeholder'
+    artalk.update({ placeholder: Placeholder })
+
+    const conf = artalk.getConf()
+    expect(conf.placeholder).toBe(Placeholder)
+    expect(conf.gravatar, "the gravatar which not in update should keep the same").toEqual(RemoteConf.gravatar)
+  })
+
+  it('should can set dark mode (artalk.setDarkMode)', () => {
+    const el = artalk.getEl()
+    expect(artalk.getConf().darkMode).toBe(true)
+    expect(el.classList.contains('atk-dark-mode')).toBe(true)
+    artalk.setDarkMode(false)
+    expect(artalk.getConf().darkMode).toBe(false)
+    expect(el.classList.contains('atk-dark-mode')).toBe(false)
+  })
+
+  it('should can reload comments (artalk.reload)', async () => {
+    artalk.reload()
+
+    const fn = vi.fn()
+
+    await new Promise(resolve => {
+      artalk.on('list-loaded', () => {
+        resolve(null)
+        fn()
+      })
+    })
+
+    expect(fn).toBeCalledTimes(1)
+  })
+
+  it('should can destroy (artalk.destroy)', () => {
+    artalk.destroy()
+
+    // detect if it is cleaned up
+    const selectors = [`#${ContainerID}`, '.atk-layer-wrap']
+    selectors.forEach(selector => {
+      const el = document.querySelector(selector)
+      expect(el).toBe(null)
+    })
+  })
+})

--- a/ui/artalk/tests/ui-api.test.ts
+++ b/ui/artalk/tests/ui-api.test.ts
@@ -117,6 +117,17 @@ describe('Artalk instance', () => {
     expect(conf.gravatar, "the gravatar which not in update should keep the same").toEqual(RemoteConf.gravatar)
   })
 
+  it('should can getEl after config updated (artalk.getEl)', () => {
+    const target = document.getElementById(ContainerID)
+    expect(target).not.toBe(null)
+
+    const el = artalk.getEl()
+    expect(el).toBe(target)
+
+    const el2 = artalk.getConf().el
+    expect(el2).toBe(target)
+  })
+
   it('should can set dark mode (artalk.setDarkMode)', () => {
     const el = artalk.getEl()
     expect(artalk.getConf().darkMode).toBe(true)

--- a/ui/artalk/types/config.ts
+++ b/ui/artalk/types/config.ts
@@ -129,6 +129,7 @@ export interface ArtalkConfig {
   remoteConfModifier?: (conf: Partial<ArtalkConfig>) => void
   listUnreadHighlight?: boolean
   scrollRelativeTo?: () => HTMLElement
+  immediateFetch?: boolean
 }
 
 /**

--- a/ui/artalk/types/context.ts
+++ b/ui/artalk/types/context.ts
@@ -79,6 +79,9 @@ export interface ContextApi extends EventManagerFuncs<EventPayloadMap> {
   /** 设置夜间模式 */
   setDarkMode(darkMode: boolean|'auto'): void
 
+  /** 获取配置 */
+  getConf(): ArtalkConfig
+
   /** 更新配置 */
   updateConf(conf: Partial<ArtalkConfig>): void
 }

--- a/ui/artalk/types/event.ts
+++ b/ui/artalk/types/event.ts
@@ -9,6 +9,7 @@ interface ListFetchedArgs { params: Partial<ListFetchParams>, data?: ListData, e
 export interface EventPayloadMap {
   'inited': undefined              // Artalk 初始化后
   'destroy': undefined             // Artalk 销毁时
+  'conf-fetch': undefined          // 配置请求时
   'list-fetch': Partial<ListFetchParams>    // 评论列表请求时
   'list-fetched': ListFetchedArgs           // 评论列表请求后
   'list-load': CommentData[]     // 评论装载前

--- a/ui/artalk/vitest.config.ts
+++ b/ui/artalk/vitest.config.ts
@@ -10,7 +10,7 @@ export default mergeConfig(
       environment: 'jsdom',
       exclude: [...configDefaults.exclude, 'tests/e2e/*'],
       root: fileURLToPath(new URL('./', import.meta.url)),
-      setupFiles: [resolve(__dirname, '/tests/setup.ts')],
+      setupFiles: ['tests/setup.ts'],
     }
   })
 )


### PR DESCRIPTION
- 增加 `artalk.init`、`artalk.updateConf` 等操作的单元测试
- 修改 `mergeDeep` 函数为创建新对象（immutable）, 而不再是 in-place 作用于原始对象（不再修改调用函数时传入的对象）
- 增加 `getConf`、`getEl` 函数，同时弃用 `artalk.conf`、`artalk.$root`

Close #720
Close #719
Close #718 