### PR TITLE
修复onBeforeUnmounted在 vue3 报错

### DIFF
--- a/docs/docs/guide/frontend/import-framework.md
+++ b/docs/docs/guide/frontend/import-framework.md
@@ -15,7 +15,7 @@ Vue 3 + TypeScript 例：
 ```vue
 <script lang="ts" setup>
 import Artalk from 'artalk'
-import { onBeforeUnmounted, onMounted, ref } from 'vue'
+import { onBeforeUnmount, onMounted, ref } from 'vue'
 import { useRoute } from 'vue-router'
 
 import 'artalk/dist/Artalk.css'
@@ -36,7 +36,7 @@ onMounted(() => {
   })
 })
 
-onBeforeUnmounted(() => {
+onBeforeUnmount(() => {
   artalk.destroy()
 })
 </script>


### PR DESCRIPTION
在vue3中应当使用onBeforeUnmount，否则会出现报错
```
Uncaught SyntaxError: The requested module '/node_modules/.vite/deps/vue.js?v=8d0cccb1' does not provide an export named 'onBeforeUnmounted' (at Talk.vue:3:10)
```