### PR TITLE
fix(docs): JSON syntax errors in the import-blog  hexo example

### DIFF
--- a/docs/docs/guide/frontend/import-blog.md
+++ b/docs/docs/guide/frontend/import-blog.md
@@ -76,7 +76,7 @@ params:
     el: '#Comments',
     pageKey: '<%= page.permalink %>',
     pageTitle: '<%= page.title %>',
-    server: '<%= theme.comment.artalk.server %>'
+    server: '<%= theme.comment.artalk.server %>',
     site: '<%= theme.comment.artalk.site %>',
   })
 </script>


### PR DESCRIPTION
我跟着“置入博客”文档，将 Artalk 引入 Hexo 博客中，发现示例 `artalk.ejs` 中的代码少了个逗号。😁 @qwqcode 