### PR TITLE
refactor(transfer): strip domain from page key by default

### DIFF
--- a/docs/docs/guide/transfer.md
+++ b/docs/docs/guide/transfer.md
@@ -184,7 +184,8 @@ Artalk 导入功能的通用启动参数：
 | :----------------: | ------- | --------------------------------------------------------------------------------------------------------- |
 | `target_site_name` | String  | 导入站点名称                                                                                              |
 | `target_site_url`  | String  | 导入站点 URL                                                                                              |
-|   `url_resolver`   | Boolean | 默认关闭，URL 解析器。将 `page_key` 基于 `target_site_url` 参数重新生成为完整 URL 作为评论的新 `page_key` |
+|   `url_resolver`   | Boolean | 默认关闭，URL 解析器。将 `page_key` 基于 `target_site_url` 参数重新生成为完整 URL 作为评论的新 `page_key`     |
+|   `url_keep_domain`| Boolean | 默认关闭，是否保留原有 URL 的域名部分。当关闭时将去除 `pageKey` 中的域名。当 `url_resolver` 开启时，`url_keep_domain` 将被同时启用 |
 |    `json_file`     | String  | JSON 数据文件路径                                                                                         |
 |    `json_data`     | String  | JSON 数据字符串内容                                                                                       |
 |    `assumeyes`     | Boolean | 不提确认 `y/n`，直接执行                                                                                  |

--- a/internal/artransfer/base.go
+++ b/internal/artransfer/base.go
@@ -44,11 +44,13 @@ func ArrToImportParams(arr []string) *ImportParams {
 	params := ImportParams{}
 
 	params.UrlResolver = false // 默认关闭
+	params.UrlKeepDomain = false
 
 	getParamsFrom(arr).To(map[string]any{
 		"target_site_name": &params.TargetSiteName,
 		"target_site_url":  &params.TargetSiteUrl,
 		"url_resolver":     &params.UrlResolver,
+		"url_keep_domain":  &params.UrlKeepDomain,
 		"json_file":        &params.JsonFile,
 		"json_data":        &params.JsonData,
 		"assumeyes":        &params.Assumeyes,

--- a/internal/artransfer/importer.go
+++ b/internal/artransfer/importer.go
@@ -18,6 +18,7 @@ type ImportParams struct {
 	TargetSiteName string `json:"target_site_name" form:"target_site_name" validate:"optional"` // The target site name
 	TargetSiteUrl  string `json:"target_site_url" form:"target_site_url" validate:"optional"`   // The target site url
 	UrlResolver    bool   `json:"url_resolver" form:"url_resolver" validate:"optional"`         // Enable URL resolver
+	UrlKeepDomain  bool   `json:"url_keep_domain" form:"url_keep_domain" validate:"optional"`   // Keep domain
 	JsonFile       string `json:"json_file,omitempty" form:"json_file" validate:"optional"`     // The JSON file path
 	JsonData       string `json:"json_data,omitempty" form:"json_data" validate:"optional"`     // The JSON data
 	Assumeyes      bool   `json:"assumeyes" form:"assumeyes" validate:"optional"`               // Automatically answer yes for all questions.
@@ -32,6 +33,10 @@ func importArtrans(dao *dao.Dao, params *ImportParams, comments []*entity.Artran
 	if params.TargetSiteUrl != "" && !utils.ValidateURL(params.TargetSiteUrl) {
 		logFatal(i18n.T("Invalid {{name}}", map[string]interface{}{"name": i18n.T("Target Site") + " " + "URL"}))
 		return
+	}
+
+	if params.UrlResolver {
+		params.UrlKeepDomain = true
 	}
 
 	// 汇总
@@ -127,6 +132,9 @@ func importArtrans(dao *dao.Dao, params *ImportParams, comments []*entity.Artran
 				return
 			}
 			nPageKey = urlResolverGetPageKey(splittedURLs[0], c.PageKey)
+		}
+		if !params.UrlKeepDomain { // strip domain from page key
+			nPageKey = stripDomainFromURL(nPageKey)
 		}
 
 		page := dao.FindCreatePage(nPageKey, c.PageTitle, site.Name)

--- a/internal/artransfer/url_resolver_test.go
+++ b/internal/artransfer/url_resolver_test.go
@@ -1,0 +1,31 @@
+package artransfer
+
+import (
+	"testing"
+)
+
+func Test_urlResolverGetPageKey(t *testing.T) {
+	type args struct {
+		baseUrlRaw    string
+		commentUrlRaw string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"Domain-only combine with Path-only", args{"https://github.com", "/1.html"}, "https://github.com/1.html"},
+		{"Domain-only combine with Domain-Path", args{"https://github.com", "https://xxx.com/1.html"}, "https://github.com/1.html"},
+		{"Domain-only (trailing slash) combine with Path-only", args{"https://github.com/", "/1.html"}, "https://github.com/1.html"},
+		{"Empty combine with Path-only", args{"", "/1.html"}, "/1.html"},
+		{"Empty combine with Domain-Path", args{"", "https://xxx.com/1.html"}, "https://xxx.com/1.html"},
+		{"Domain-Path (no trailing slash) combine with Path-only (trailing slash)", args{"https://github.com/233", "/1/"}, "https://github.com/1/"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := urlResolverGetPageKey(tt.args.baseUrlRaw, tt.args.commentUrlRaw); got != tt.want {
+				t.Errorf("urlResolverGetPageKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/artransfer/utils.go
+++ b/internal/artransfer/utils.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/ArtalkJS/Artalk/internal/i18n"
 	"github.com/araddon/dateparse"
@@ -26,18 +25,6 @@ func readJsonFile(filename string) (string, error) {
 	}
 
 	return string(buf), nil
-}
-
-func hideJsonLongText(key string, text string) string {
-	r := regexp.MustCompile(key + `:"(.+?)"`)
-	sm := r.FindStringSubmatch(text)
-	postText := ""
-	if len(sm) > 0 {
-		postText = sm[1]
-	}
-
-	text = r.ReplaceAllString(text, fmt.Sprintf(key+": <!-- 省略 %d 个字符 -->", utf8.RuneCountInString(postText)))
-	return text
 }
 
 func parseDate(s string) time.Time {
@@ -78,4 +65,13 @@ func getParamsFrom(arr []string) getParamsFromTo {
 		}
 	}
 	return a
+}
+
+func stripDomainFromURL(fullURL string) string {
+	re := regexp.MustCompile(`^https?://[^/]+`)
+	result := re.ReplaceAllString(fullURL, "")
+	if result == "" {
+		result = "/"
+	}
+	return result
 }

--- a/internal/artransfer/utils_test.go
+++ b/internal/artransfer/utils_test.go
@@ -1,0 +1,26 @@
+package artransfer
+
+import "testing"
+
+func Test_stripDomainFromURL(t *testing.T) {
+	type args struct {
+		fullURL string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"1", args{"https://github.com/abc"}, "/abc"},
+		{"2", args{"https://domain.com/some/path?query=123#section"}, "/some/path?query=123#section"},
+		{"3", args{"https://domain.com"}, "/"},
+		{"4", args{"/some/path?query=123#section"}, "/some/path?query=123#section"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripDomainFromURL(tt.args.fullURL); got != tt.want {
+				t.Errorf("stripDomainFromURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Artrans 文件的评论 PageKey 可能是完整的 URL（包含 domain 部分），然而我们希望迁移到 Artalk 后 PageKey 使用相对路径以便于部署和后期迁移。

此 PR 修改 Transfer 功能：在导入评论时，默认会去掉 PageKey 中的 Domain 部分

（如果需要保留 PageKey 中的 domain，可以将导入参数 `url_keep_domain` 设置为 `true`）

---

The PageKey for Artrans file comments might be a complete URL (including the domain part). However, we hope to migrate to using relative paths for PageKey in Artalk for easier deployment and future migrations.

This PR modifies the Transfer function: when importing comments, it will, by default, remove the domain part from the PageKey.

(If it's necessary to retain the domain in the PageKey, you can set the import parameter `url_keep_domain` to `true`)