### PR TITLE
refactor(ui/stat): use class selector for pageview elements by default

### DIFF
--- a/conf/artalk.example.simple.yml
+++ b/conf/artalk.example.simple.yml
@@ -229,8 +229,9 @@ frontend:
   voteDown: false
   uaBadge: false
   listSort: true
-  pvEl: "#ArtalkPV"
-  countEl: "#ArtalkCount"
+  pvEl: ".artalk-pv-count"
+  countEl: ".artalk-comment-count"
+  statPageKeyAttr: "data-page-key"
   preview: true
   flatMode: auto
   darkMode: inherit

--- a/conf/artalk.example.yml
+++ b/conf/artalk.example.yml
@@ -405,9 +405,11 @@ frontend:
   # Comment sorting
   listSort: true
   # Page PV binding element
-  pvEl: "#ArtalkPV"
+  pvEl: ".artalk-pv-count"
   # Comment count binding element
-  countEl: "#ArtalkCount"
+  countEl: ".artalk-comment-count"
+  # Statistic PageKey attribute
+  statPageKeyAttr: "data-page-key"
   # Editor real-time preview
   preview: true
   # Flatten mode ["auto", true, false]

--- a/conf/artalk.example.zh-CN.yml
+++ b/conf/artalk.example.zh-CN.yml
@@ -410,9 +410,11 @@ frontend:
   # 评论排序功能
   listSort: true
   # 页面 PV 绑定元素
-  pvEl: "#ArtalkPV"
+  pvEl: ".artalk-pv-count"
   # 评论数绑定元素
-  countEl: "#ArtalkCount"
+  countEl: ".artalk-comment-count"
+  # 统计组件 PageKey 属性名
+  statPageKeyAttr: "data-page-key"
   # 编辑器实时预览功能
   preview: true
   # 平铺模式 ["auto", true, false]

--- a/docs/docs/guide/frontend/config.md
+++ b/docs/docs/guide/frontend/config.md
@@ -221,30 +221,41 @@ artalk.setDarkMode(true)
 **页面浏览量 (PV) 绑定元素**
 
 - 类型：`String`
-- 默认值：`"#ArtalkPV"`
+- 默认值：`".artalk-pv-count"`
 
-你可以在页面任意位置，放置 HTML 标签：`<span id="ArtalkPV"></span>`
+你可以在页面任意位置，放置 HTML 标签：`<span class="artalk-pv-count"></span>`
 
 当 Artalk 完成加载时展示页面的浏览量。
 
-该项填入绑定元素的 Selector，默认为 `#ArtalkPV`。
+该项填入绑定元素的 Selector，默认为 `.artalk-pv-count`。
 
 ### countEl
 
 **评论数绑定元素**
 
 - 类型：`String`
-- 默认值：`"#ArtalkCount"`
+- 默认值：`".artalk-comment-count"`
 
-你可以在页面任意位置，放置 HTML 标签：`<span id="ArtalkCount"></span>` 显示当前页面的评论数。
+你可以在页面任意位置，放置 HTML 标签：`<span class="artalk-comment-count"></span>` 显示当前页面的评论数。
 
 ::: tip
 
-pvEl 和 countEl 元素标签都可以设置 `data-page-key` 属性值，来指定显示某个页面的统计数目，例如：`<span id="ArtalkCount" data-page-key="/t/1.html"></span>`
+pvEl 和 countEl 元素标签都可以设置 `data-page-key` 属性值，来指定显示某个页面的统计数目，例如：`<span class="artalk-comment-count" data-page-key="/t/1.html"></span>`
 
-详情参考：[浏览量统计](./pv.md#显示多个页面的浏览量)
+详情参考：[浏览量统计](./pv.md#同时加载多个页面的统计数)
 
 :::
+
+### statPageKeyAttr
+
+**统计组件 PageKey 属性名**
+
+- 类型：`String`
+- 默认值：`"data-page-key"`
+
+Artalk 统计组件查询评论数和浏览量时，会通过该属性名来查询指定页面，例如：`<span data-page-key="/t/1.html"></span>`。
+
+为了便于主题适配，可根据需要自定义属性名，例如将其替换为 `data-path`，则 HTML 标签为 `<span data-path="/t/1.html"></span>`。
 
 ### vote
 

--- a/docs/docs/guide/frontend/pv.md
+++ b/docs/docs/guide/frontend/pv.md
@@ -1,53 +1,81 @@
 # 浏览量统计
 
-Artalk 内置页面浏览量统计功能，你可以在你的页面任意位置，放置 HTML 标签：
+Artalk 内置页面浏览量统计和评论数统计功能，你可以在页面中显示页面的浏览量和评论数。
 
 ```html
-<span id="ArtalkPV"></span>
+浏览量：<span class="artalk-pv-count"></span>
+评论数：<span class="artalk-comment-count"></span>
 ```
 
-当 Artalk 评论列表加载完毕时，该标签内容将修改为页面的浏览量计数。
+## 加载占位符
 
-Artalk 加载需要时间，所以你可以给它一个占位字符：
+Artalk 加载需要时间，你可以在展示统计数的元素中加入占位符：
 
 ```html
-<span id="ArtalkPV">加载中...</span>
+<span class="artalk-pv-count">加载中...</span>
 ```
 
-配置项 `pvEl` 的默认值是 `"#ArtalkPV"`，可修改将评论量加载到指定元素，例如：
+## 同时加载多个页面的统计数
 
-```js
-Artalk.init({
-  pvEl: '.your_element',
-})
-```
+例如在文章列表页，你可以显示每篇文章的浏览量和评论数。
 
-### 加载多个页面的浏览量
-
-你能在除评论页面之外的任何页面，例如「文章列表」页，显示页面浏览量或评论数。
-
-在非评论页，无需调用 `Artalk.init` 加载评论框 (会使页面浏览量 PV 数增加)，仅调用 `loadCountWidget` 静态方法即可：
+当处于文章列表页时，仅需调用 `Artalk.loadCountWidget` 函数，而无需 `Artalk.init` (加载评论列表会使页面浏览量 PV 数 +1)。
 
 <!-- prettier-ignore-start -->
-
 
 ```js
 Artalk.loadCountWidget({
   server: '服务器地址',
   site: '站点名',
-  pvEl: '#ArtalkPV',
-  countEl: '#ArtalkCount',
+  pvEl: '.artalk-pv-count',
+  countEl: '.artalk-comment-count',
+  statPageKeyAttr: 'data-page-key',
 })
 ```
 
 <!-- prettier-ignore-end -->
 
-然后你可以放置多个 `#ArtalkPV` 元素，通过属性 `data-page-key` 来指定需要查询的页面：
+然后放置多个 class 为 `artalk-pv-count` 的元素，通过属性 `data-page-key` 来指定需要查询的页面：
 
 ```html
-<span id="ArtalkPV" data-page-key="/test/1.html"></span>
-<span id="ArtalkPV" data-page-key="/test/2.html"></span>
-<span id="ArtalkPV" data-page-key="/test/3.html"></span>
-<span id="ArtalkCount" data-page-key="/test/1.html"></span>
-<!-- ... -->
+<span class="artalk-pv-count" data-page-key="/test/1.html"></span>
+<span class="artalk-pv-count" data-page-key="/test/2.html"></span>
+<span class="artalk-pv-count" data-page-key="/test/3.html"></span>
 ```
+
+评论数查询同理：
+
+```html
+<span class="artalk-comment-count" data-page-key="/test/1.html"></span>
+<span class="artalk-comment-count" data-page-key="/test/2.html"></span>
+<span class="artalk-comment-count" data-page-key="/test/3.html"></span>
+```
+
+## 自定义元素选择器
+
+可通过配置项 `pvEl` 和 `countEl` 来指定元素选择器，以展示页面浏览量和评论数：
+
+```js
+Artalk.init({
+  pvEl: '.your_pv_count_element',  // 页面浏览量元素选择器
+  countEl: '.your_comment_count_element',  // 评论数元素选择器
+})
+```
+
+## 自定义 `data-page-key` 属性名
+
+配置项 `statPageKeyAttr` 的默认值为 `data-page-key`，Artalk 会通过该属性名来查询指定页面。为了方便博客主题的适配，可通过它自定义属性名，例如将其替换为 `data-path`：
+
+```js
+Artalk.loadCountWidget({
+  statPageKeyAttr: 'data-path',
+})
+```
+
+此时，对应的 HTML 代码应如下所示：
+
+```html
+<span class="artalk-pv-count" data-path="/test/1.html"></span>
+```
+
+这样，`data-path` 属性值将被用于查询指定的页面。

--- a/test/testdata/example_site_conf.yml
+++ b/test/testdata/example_site_conf.yml
@@ -141,8 +141,8 @@ frontend:
   voteDown: false
   uaBadge: true
   listSort: true
-  pvEl: "#ArtalkPV"
-  countEl: "#ArtalkCount"
+  pvEl: ".artalk-pv-count"
+  countEl: ".artalk-comment-count"
   preview: true
   flatMode: auto
   nestMax: 2

--- a/ui/artalk/src/artalk.ts
+++ b/ui/artalk/src/artalk.ts
@@ -111,6 +111,7 @@ export default class Artalk {
       siteName: conf.site,
       countEl: conf.countEl,
       pvEl: conf.pvEl,
+      pageKeyAttr: conf.statPageKeyAttr,
       pvAdd: false,
     })
   }

--- a/ui/artalk/src/comment/height-limit.ts
+++ b/ui/artalk/src/comment/height-limit.ts
@@ -27,7 +27,7 @@ export function check(conf: IHeightLimitConf, rules: THeightLimitRuleSet) {
     if (!el) return
 
     // set max height for avoiding img exceed the limit while loading
-    if (imgCheck) el.style.maxHeight = `${max + 1}px`  // allow 1px more for next detecting
+    if (imgCheck) el.style.maxHeight = `${max + 1}px` // allow 1px more for next detecting
 
     let lock = false
     const _check = () => {

--- a/ui/artalk/src/defaults.ts
+++ b/ui/artalk/src/defaults.ts
@@ -24,8 +24,9 @@ const defaults: ArtalkConfig = {
   uaBadge: true,
   listSort: true,
   preview: true,
-  countEl: '#ArtalkCount',
-  pvEl: '#ArtalkPV',
+  countEl: '.artalk-comment-count',
+  pvEl: '.artalk-pv-count',
+  statPageKeyAttr: 'data-page-key',
 
   gravatar: {
     mirror: 'https://cravatar.cn/avatar/',

--- a/ui/artalk/src/plugins/stat.ts
+++ b/ui/artalk/src/plugins/stat.ts
@@ -103,7 +103,7 @@ async function loadStatCount(args: {
 /** Retrieve elements based on selectors */
 function retrieveElements(containers: string[]): Set<HTMLElement> {
   const els = new Set<HTMLElement>()
-  containers.forEach((selector) => {
+  new Set(containers).forEach((selector) => {
     document.querySelectorAll<HTMLElement>(selector).forEach((el) => els.add(el))
   })
   return els

--- a/ui/artalk/src/types/config.ts
+++ b/ui/artalk/src/types/config.ts
@@ -81,6 +81,9 @@ export interface ArtalkConfig {
   /** PV 数绑定元素 Selector */
   pvEl: string
 
+  /** 统计组件 PageKey 属性名 */
+  statPageKeyAttr: string
+
   /** 夜间模式 */
   darkMode: boolean | 'auto'
 

--- a/ui/artalk/tests/stat-plugin.test.ts
+++ b/ui/artalk/tests/stat-plugin.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { exportedForTesting } from '@/plugins/stat'
+import type { CountOptions } from '@/plugins/stat'
+
+const {
+  incrementPvCount,
+  loadCommentCount,
+  loadPvCount,
+  retrieveElements,
+  getPageKeys,
+  updateElementsText,
+} = exportedForTesting
+
+// Mocking API
+const mockApi = {
+  pages: {
+    logPv: vi.fn().mockResolvedValue({ data: { pv: 100 } }),
+  },
+  stats: {
+    getStats: vi.fn().mockResolvedValue({
+      data: { data: { 'test-page-key': 5 } },
+    }),
+  },
+}
+
+// Mocking CountOptions
+const mockOptions: CountOptions = {
+  getApi: () => mockApi as any,
+  siteName: 'test-site',
+  pageKey: 'test-page-key',
+  pageTitle: 'Test Page',
+  countEl: '.count-element',
+  pvEl: '.pv-element',
+  pageKeyAttr: 'data-page-key',
+  pvAdd: true,
+}
+
+describe('PvCountWidget', () => {
+  it('should increment PV count and get cache data', async () => {
+    const cacheData = await incrementPvCount(mockOptions)
+    expect(mockApi.pages.logPv).toHaveBeenCalledWith({
+      page_key: 'test-page-key',
+      page_title: 'Test Page',
+      site_name: 'test-site',
+    })
+    expect(cacheData).toEqual({ 'test-page-key': 100 })
+  })
+
+  it('should load comment count', async () => {
+    document.body.innerHTML = '<div class="count-element" data-page-key="test-page-key"></div>'
+    await loadCommentCount(mockOptions)
+    const el = document.querySelector<HTMLElement>('.count-element')
+    expect(el?.innerText).toBe('5')
+  })
+
+  it('should load PV count', async () => {
+    document.body.innerHTML = '<div class="pv-element" data-page-key="test-page-key"></div>'
+    await loadPvCount(mockOptions, { 'test-page-key': 100 })
+    const el = document.querySelector<HTMLElement>('.pv-element')
+    expect(el?.innerText).toBe('100')
+  })
+
+  it('should retrieve elements based on selectors', () => {
+    document.body.innerHTML = `
+      <div class="test-element"></div>
+      <div class="test-element"></div>
+    `
+    const elements = retrieveElements(['.test-element'])
+    expect(elements.size).toBe(2)
+  })
+
+  it('should get page keys to be queried', () => {
+    document.body.innerHTML = `
+      <div class="test-element" data-page-key="key1"></div>
+      <div class="test-element" data-page-key="key2"></div>
+    `
+    const elements = retrieveElements(['.test-element'])
+    const pageKeys = getPageKeys(elements, 'data-page-key', undefined, {})
+    expect(pageKeys).toEqual(['key1', 'key2'])
+  })
+
+  it('should update elements text content with the count data', () => {
+    document.body.innerHTML = `
+      <div class="test-element" data-page-key="key1"></div>
+      <div class="test-element" data-page-key="key2"></div>
+      <div class="test-element"></div>
+    `
+    const elements = retrieveElements(['.test-element'])
+    const data = { key1: 10, key2: 20 }
+    updateElementsText(elements, data, 'defaultKey')
+    const els = document.querySelectorAll<HTMLElement>('.test-element')
+    expect(els[0].innerText).toBe('10')
+    expect(els[1].innerText).toBe('20')
+    expect(els[2].innerText).toBe('0')
+  })
+})


### PR DESCRIPTION
The statistics UI component has been updated. The default selectors for `pvEl` and `countEl` have changed from `#ArtalkPV` and `#ArtalkCount` to `.artalk-pv-count` and `.artalk-comment-count` (see #826 for more details). However, it remains backward compatible with the `#ArtalkPV` and `#ArtalkCount` elements for older versions, no HTML client updates are necessary.

In this PR, we also introduced a configuration option called `statPageKeyAttr` (value `"data-page-key"` by default) for customizing the attribute name that the statistics component uses to fetch the page key.

fixes #826