### PR TITLE
refactor(dao): improve `QueryDBWithCache` func and concurrent unit tests

### DIFF
--- a/internal/cache/base_test.go
+++ b/internal/cache/base_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func newCache(t *testing.T) *cache.Cache {
+func newTestCache(t *testing.T) *cache.Cache {
 	cache, err := cache.New(config.CacheConf{
 		Enabled: true,
 		Type:    config.CacheTypeBuiltin,
@@ -20,7 +20,7 @@ func newCache(t *testing.T) *cache.Cache {
 }
 
 func TestNew(t *testing.T) {
-	cache := newCache(t)
+	cache := newTestCache(t)
 	defer cache.Close()
 
 	assert.NotNil(t, cache)

--- a/internal/dao/query_find_create.go
+++ b/internal/dao/query_find_create.go
@@ -38,7 +38,7 @@ func FindCreateAction[T EntityHasIsEmpty](
 	})
 	if err != nil {
 		log.Error("[FindCreate] ", err)
-		return result.(T), err
+		return *new(T), err
 	}
 	return result.(T), nil
 }

--- a/test/testdata/model_test_conf.yml
+++ b/test/testdata/model_test_conf.yml
@@ -7,6 +7,8 @@ debug: false
 # 时区
 timezone: Asia/Shanghai
 
+locale: en
+
 # 日志
 log:
   enabled: false
@@ -29,3 +31,9 @@ admin_users:
     password: "123456" # 密码支持 bcrypt 或 md5 加密，例如填写："(md5)50c21190c6e4e5418c6a90d2b5031119"
     badge_name: 管理员
     badge_color: "#FF6C00"
+
+http:
+  proxy_header: ""
+
+img_upload:
+  path: ./data/artalk-img


### PR DESCRIPTION
This PR includes the following improvements:

- Changed the `QueryDBWithCache` function's pointer parameter passing and in-place editing to explicit function input and output passing, and errors are no longer ignored.
- Fixed concurrent unit tests, which previously had intermittent errors (caused by using different keys during concurrent test cases, expected to use the same key).
- Reviewed and ensured thread safety once again.