### PR TITLE
refactor(plugin_katex): use tokenizer extension of marked

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,6 +301,9 @@ importers:
 
   ui/plugin-katex:
     dependencies:
+      '@types/katex':
+        specifier: ^0.16.7
+        version: 0.16.7
       artalk:
         specifier: workspace:^
         version: link:../artalk
@@ -311,9 +314,9 @@ importers:
       '@artalk/plugin-kit':
         specifier: workspace:^
         version: link:../plugin-kit
-      '@types/katex':
-        specifier: 0.16.7
-        version: 0.16.7
+      marked:
+        specifier: ^14.0.0
+        version: 14.0.0
 
   ui/plugin-kit:
     dependencies:

--- a/ui/plugin-katex/package.json
+++ b/ui/plugin-katex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artalk/plugin-katex",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "minAppVersion": "2.8.6",
   "license": "MIT",
   "description": "The katex plugin for artalk",
@@ -18,14 +18,17 @@
   },
   "dependencies": {
     "artalk": "workspace:^",
-    "katex": "^0.16.10"
+    "katex": "^0.16.10",
+    "@types/katex": "^0.16.7"
   },
   "devDependencies": {
     "@artalk/plugin-kit": "workspace:^",
-    "@types/katex": "0.16.7"
+    "marked": "^14.0.0"
   },
   "peerDependencies": {
-    "artalk": "workspace:^"
+    "artalk": "workspace:^",
+    "katex": "^0.16.10",
+    "@types/katex": "^0.16.7"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
Previously, KaTeX was integrated using the `Renderer` hook provided by `marked`. Now, it has been changed to use the `TokenizerExtension`.