### PR TITLE
fix(test): separate test db to isolate concurrent test instances

### DIFF
--- a/internal/dao/query_find.go
+++ b/internal/dao/query_find.go
@@ -20,7 +20,7 @@ var noCacheFindSingleflightGroup = new(singleflight.Group)
 
 func QueryDBWithoutCache[T any](dao *Dao, name string, queryDB func() (T, error)) (T, error) {
 	v, err, _ := noCacheFindSingleflightGroup.Do(name, func() (any, error) {
-		return queryDB() // queryDB() may not be thread safe, so use singleflight.Group
+		return queryDB() // Use singleflight to prevent high concurrency pressure on DB
 	})
 	if err != nil {
 		return *new(T), err

--- a/internal/dao/query_find_create.go
+++ b/internal/dao/query_find_create.go
@@ -16,9 +16,13 @@ type EntityHasIsEmpty interface {
 	IsEmpty() bool
 }
 
-// FindCreateAction (Thread Safe)
+// FindCreateAction is a thread-safe function that attempts to find an entity
+// using the provided findAction function. If the entity does not exist or the
+// result is empty, it will execute the createAction function to create a new entity.
 //
-// Use singleflight.Group to prevent duplicate creation if multiple goroutines access at the same time.
+// The function ensures that only one goroutine can perform the find or create
+// operation for a given key at a time, using the singleflight mechanism to prevent
+// duplicate operations.
 func FindCreateAction[T EntityHasIsEmpty](
 	key string,
 	findAction func() (T, error),


### PR DESCRIPTION
Through the logs of unit tests, I observed that concurrent tests often fail, which puzzled me. Initially, I thought it was due to concurrency issues and improper locking. However, further testing revealed that the problem was not with improper locking but with the shared database and its data among these test instances. This led to dirty data being read during concurrent testing. The design did not originally consider distributed deployment, and without database-level or distributed locks, multiple instances should not access the same database simultaneously. This PR modifies the approach to create a separate, isolated database for each test instance by calling the `NewTestApp` function, preventing the issues mentioned above.