### PR TITLE
refactor(api/vote): refactor vote http endpoint and logic

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -3525,9 +3525,9 @@ const docTemplate = `{
                 }
             }
         },
-        "/votes/{type}/{target_id}": {
+        "/votes/{target_name}/{target_id}/{choice}": {
             "post": {
-                "description": "Vote for a specific comment or page",
+                "description": "Create a new vote for a specific comment or page",
                 "consumes": [
                     "application/json"
                 ],
@@ -3537,26 +3537,35 @@ const docTemplate = `{
                 "tags": [
                     "Vote"
                 ],
-                "summary": "Vote",
-                "operationId": "Vote",
+                "summary": "Create Vote",
+                "operationId": "CreateVote",
                 "parameters": [
                     {
                         "enum": [
-                            "comment_up",
-                            "comment_down",
-                            "page_up",
-                            "page_down"
+                            "comment",
+                            "page"
                         ],
                         "type": "string",
-                        "description": "The type of vote target",
-                        "name": "type",
+                        "description": "The name of vote target",
+                        "name": "target_name",
                         "in": "path",
                         "required": true
                     },
                     {
                         "type": "integer",
-                        "description": "Target comment or page ID you want to vote for",
+                        "description": "The target comment or page ID",
                         "name": "target_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "up",
+                            "down"
+                        ],
+                        "type": "string",
+                        "description": "The vote choice",
+                        "name": "choice",
                         "in": "path",
                         "required": true
                     },
@@ -3566,7 +3575,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handler.ParamsVote"
+                            "$ref": "#/definitions/handler.ParamsVoteCreate"
                         }
                     }
                 ],
@@ -4430,7 +4439,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handler.ParamsVote": {
+        "handler.ParamsVoteCreate": {
             "type": "object",
             "properties": {
                 "email": {
@@ -5405,11 +5414,19 @@ const docTemplate = `{
             "type": "object",
             "required": [
                 "down",
+                "is_down",
+                "is_up",
                 "up"
             ],
             "properties": {
                 "down": {
                     "type": "integer"
+                },
+                "is_down": {
+                    "type": "boolean"
+                },
+                "is_up": {
+                    "type": "boolean"
                 },
                 "up": {
                     "type": "integer"

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -3518,9 +3518,9 @@
                 }
             }
         },
-        "/votes/{type}/{target_id}": {
+        "/votes/{target_name}/{target_id}/{choice}": {
             "post": {
-                "description": "Vote for a specific comment or page",
+                "description": "Create a new vote for a specific comment or page",
                 "consumes": [
                     "application/json"
                 ],
@@ -3530,26 +3530,35 @@
                 "tags": [
                     "Vote"
                 ],
-                "summary": "Vote",
-                "operationId": "Vote",
+                "summary": "Create Vote",
+                "operationId": "CreateVote",
                 "parameters": [
                     {
                         "enum": [
-                            "comment_up",
-                            "comment_down",
-                            "page_up",
-                            "page_down"
+                            "comment",
+                            "page"
                         ],
                         "type": "string",
-                        "description": "The type of vote target",
-                        "name": "type",
+                        "description": "The name of vote target",
+                        "name": "target_name",
                         "in": "path",
                         "required": true
                     },
                     {
                         "type": "integer",
-                        "description": "Target comment or page ID you want to vote for",
+                        "description": "The target comment or page ID",
                         "name": "target_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "up",
+                            "down"
+                        ],
+                        "type": "string",
+                        "description": "The vote choice",
+                        "name": "choice",
                         "in": "path",
                         "required": true
                     },
@@ -3559,7 +3568,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handler.ParamsVote"
+                            "$ref": "#/definitions/handler.ParamsVoteCreate"
                         }
                     }
                 ],
@@ -4423,7 +4432,7 @@
                 }
             }
         },
-        "handler.ParamsVote": {
+        "handler.ParamsVoteCreate": {
             "type": "object",
             "properties": {
                 "email": {
@@ -5398,11 +5407,19 @@
             "type": "object",
             "required": [
                 "down",
+                "is_down",
+                "is_up",
                 "up"
             ],
             "properties": {
                 "down": {
                     "type": "integer"
+                },
+                "is_down": {
+                    "type": "boolean"
+                },
+                "is_up": {
+                    "type": "boolean"
                 },
                 "up": {
                     "type": "integer"

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -574,7 +574,7 @@ definitions:
     - name
     - receive_email
     type: object
-  handler.ParamsVote:
+  handler.ParamsVoteCreate:
     properties:
       email:
         description: The user email
@@ -1255,10 +1255,16 @@ definitions:
     properties:
       down:
         type: integer
+      is_down:
+        type: boolean
+      is_up:
+        type: boolean
       up:
         type: integer
     required:
     - down
+    - is_down
+    - is_up
     - up
     type: object
 info:
@@ -3278,34 +3284,40 @@ paths:
       summary: Get Version Info
       tags:
       - System
-  /votes/{type}/{target_id}:
+  /votes/{target_name}/{target_id}/{choice}:
     post:
       consumes:
       - application/json
-      description: Vote for a specific comment or page
-      operationId: Vote
+      description: Create a new vote for a specific comment or page
+      operationId: CreateVote
       parameters:
-      - description: The type of vote target
+      - description: The name of vote target
         enum:
-        - comment_up
-        - comment_down
-        - page_up
-        - page_down
+        - comment
+        - page
         in: path
-        name: type
+        name: target_name
         required: true
         type: string
-      - description: Target comment or page ID you want to vote for
+      - description: The target comment or page ID
         in: path
         name: target_id
         required: true
         type: integer
+      - description: The vote choice
+        enum:
+        - up
+        - down
+        in: path
+        name: choice
+        required: true
+        type: string
       - description: The vote data
         in: body
         name: vote
         required: true
         schema:
-          $ref: '#/definitions/handler.ParamsVote'
+          $ref: '#/definitions/handler.ParamsVoteCreate'
       produces:
       - application/json
       responses:
@@ -3340,7 +3352,7 @@ paths:
                 msg:
                   type: string
               type: object
-      summary: Vote
+      summary: Create Vote
       tags:
       - Vote
   /votes/sync:

--- a/internal/dao/query_find.go
+++ b/internal/dao/query_find.go
@@ -222,11 +222,11 @@ func (dao *Dao) GetVoteNum(targetID uint, voteType string) int {
 	return int(num)
 }
 
-func (dao *Dao) GetVoteNumUpDown(targetID uint, voteTo string) (int, int) {
+func (dao *Dao) GetVoteNumUpDown(targetName string, targetID uint) (int, int) {
 	var up int64
 	var down int64
-	dao.DB().Model(&entity.Vote{}).Where("target_id = ? AND type = ?", targetID, voteTo+"_up").Count(&up)
-	dao.DB().Model(&entity.Vote{}).Where("target_id = ? AND type = ?", targetID, voteTo+"_down").Count(&down)
+	dao.DB().Model(&entity.Vote{}).Where("target_id = ? AND type = ?", targetID, targetName+"_up").Count(&up)
+	dao.DB().Model(&entity.Vote{}).Where("target_id = ? AND type = ?", targetID, targetName+"_down").Count(&down)
 	return int(up), int(down)
 }
 

--- a/server/handler/vote.go
+++ b/server/handler/vote.go
@@ -4,48 +4,79 @@ import (
 	"strings"
 
 	"github.com/artalkjs/artalk/v2/internal/core"
+	"github.com/artalkjs/artalk/v2/internal/dao"
 	"github.com/artalkjs/artalk/v2/internal/entity"
 	"github.com/artalkjs/artalk/v2/internal/i18n"
 	"github.com/artalkjs/artalk/v2/server/common"
 	"github.com/gofiber/fiber/v2"
 )
 
-type ParamsVote struct {
+type ResponseVote struct {
+	Up     int  `json:"up"`
+	Down   int  `json:"down"`
+	IsUp   bool `json:"is_up"`
+	IsDown bool `json:"is_down"`
+}
+
+type ParamsVoteCreate struct {
 	Name  string `json:"name" validate:"optional"`  // The username
 	Email string `json:"email" validate:"optional"` // The user email
 }
 
-type ResponseVote struct {
-	Up   int `json:"up"`
-	Down int `json:"down"`
-}
-
-// @Id           Vote
-// @Summary      Vote
-// @Description  Vote for a specific comment or page
+// @Id           CreateVote
+// @Summary      Create Vote
+// @Description  Create a new vote for a specific comment or page
 // @Tags         Vote
-// @Param        type       path  string      true  "The type of vote target"  Enums(comment_up, comment_down, page_up, page_down)
-// @Param        target_id  path  int         true  "Target comment or page ID you want to vote for"
-// @Param        vote       body  ParamsVote  true  "The vote data"
+// @Param        target_name  path  string            true  "The name of vote target"  Enums(comment, page)
+// @Param        target_id    path  int               true  "The target comment or page ID"
+// @Param        choice       path  string            true  "The vote choice"          Enums(up, down)
+// @Param        vote         body  ParamsVoteCreate  true  "The vote data"
 // @Accept       json
 // @Produce      json
 // @Success      200  {object}  ResponseVote
 // @Failure      403  {object}  Map{msg=string}
 // @Failure      404  {object}  Map{msg=string}
 // @Failure      500  {object}  Map{msg=string}
-// @Router       /votes/{type}/{target_id}  [post]
-func Vote(app *core.App, router fiber.Router) {
-	router.Post("/votes/:type/:target_id", common.LimiterGuard(app, func(c *fiber.Ctx) error {
-		rawType := c.Params("type")
+// @Router       /votes/{target_name}/{target_id}/{choice}  [post]
+func VoteCreate(app *core.App, router fiber.Router) {
+	router.Post("/votes/:target_name/:target_id/:choice", common.LimiterGuard(app, func(c *fiber.Ctx) error {
+		targetName := c.Params("target_name")
 		targetID, _ := c.ParamsInt("target_id")
+		choice := c.Params("choice")
+		ip := c.IP()
 
-		var p ParamsVote
+		var p ParamsVoteCreate
 		if isOK, resp := common.ParamsDecode(c, &p); !isOK {
 			return resp
 		}
 
-		// find user
-		var user entity.User
+		if choice != "up" && choice != "down" {
+			return common.RespError(c, 404, "unknown vote choice")
+		}
+
+		// Find the target model
+		var (
+			comment entity.Comment
+			page    entity.Page
+			user    entity.User
+		)
+
+		switch targetName {
+		case "comment":
+			comment = app.Dao().FindComment(uint(targetID))
+			if comment.IsEmpty() {
+				return common.RespError(c, 404, i18n.T("{{name}} not found", Map{"name": i18n.T("Comment")}))
+			}
+		case "page":
+			page = app.Dao().FindPageByID(uint(targetID))
+			if page.IsEmpty() {
+				return common.RespError(c, 404, i18n.T("{{name}} not found", Map{"name": i18n.T("Page")}))
+			}
+		default:
+			return common.RespError(c, 404, "unknown vote target name")
+		}
+
+		// Find user
 		if p.Name != "" && p.Email != "" {
 			var err error
 			user, err = app.Dao().FindCreateUser(p.Name, p.Email, "")
@@ -54,90 +85,101 @@ func Vote(app *core.App, router fiber.Router) {
 			}
 		}
 
-		ip := c.IP()
+		// Sync target model field value
+		sync := func() (int, int) {
+			up, down := app.Dao().GetVoteNumUpDown(targetName, uint(targetID))
 
-		// check type
-		isVoteComment := strings.HasPrefix(rawType, "comment_")
-		isVotePage := strings.HasPrefix(rawType, "page_")
-		isUp := strings.HasSuffix(rawType, "_up")
-		isDown := strings.HasSuffix(rawType, "_down")
-		voteTo := strings.TrimSuffix(strings.TrimSuffix(rawType, "_up"), "_down")
-		voteType := strings.TrimPrefix(strings.TrimPrefix(rawType, "comment_"), "page_")
-
-		if !isUp && !isDown {
-			return common.RespError(c, 404, "unknown type")
-		}
-
-		var comment entity.Comment
-		var page entity.Page
-
-		switch {
-		case isVoteComment:
-			comment = app.Dao().FindComment(uint(targetID))
-			if comment.IsEmpty() {
-				return common.RespError(c, 404, i18n.T("{{name}} not found", Map{"name": i18n.T("Comment")}))
-			}
-		case isVotePage:
-			page = app.Dao().FindPageByID(uint(targetID))
-			if page.IsEmpty() {
-				return common.RespError(c, 404, i18n.T("{{name}} not found", Map{"name": i18n.T("Page")}))
-			}
-		default:
-			return common.RespError(c, 404, "unknown type")
-		}
-
-		// sync target model field value
-		save := func(up int, down int) {
-			switch {
-			case isVoteComment:
+			switch targetName {
+			case "comment":
 				comment.VoteUp = up
 				comment.VoteDown = down
 				app.Dao().UpdateComment(&comment)
-			case isVotePage:
+			case "page":
 				page.VoteUp = up
 				page.VoteDown = down
 				app.Dao().UpdatePage(&page)
 			}
+
+			return up, down
 		}
 
-		createNew := func(t string) error {
-			// create new vote record
-			_, err := app.Dao().NewVote(uint(targetID), entity.VoteType(t), user.ID, string(c.Request().Header.UserAgent()), ip)
-
-			return err
-		}
-
-		// un-vote
-		var availableVotes []entity.Vote
-		app.Dao().DB().Where("target_id = ? AND type LIKE ? AND ip = ?", uint(targetID), voteTo+"%", ip).Find(&availableVotes)
-		if len(availableVotes) > 0 {
-			for _, v := range availableVotes {
-				app.Dao().DB().Unscoped().Delete(&v)
-			}
-
-			avaVoteType := strings.TrimPrefix(strings.TrimPrefix(string(availableVotes[0].Type), "comment_"), "page_")
-			if voteType != avaVoteType {
-				createNew(rawType)
-			}
-
-			up, down := app.Dao().GetVoteNumUpDown(uint(targetID), voteTo)
-			save(up, down)
-
-			return common.RespData(c, ResponseVote{
-				Up:   up,
-				Down: down,
+		// Create new vote record
+		create := func(choice string) error {
+			return createVote(app.Dao(), createNewVoteParams{
+				ip:         ip,
+				ua:         string(c.Request().Header.UserAgent()),
+				userID:     user.ID,
+				targetName: targetName,
+				targetID:   uint(targetID),
+				choice:     choice,
 			})
 		}
 
-		createNew(rawType)
+		exitsVotes := getExistsVotesByIP(app.Dao(), ip, targetName, uint(targetID))
+		if len(exitsVotes) == 0 {
+			// vote
+			create(choice)
+		} else {
+			exitsChoice := getVoteChoice(string(exitsVotes[0].Type))
+
+			// un-vote all if already exists
+			for _, v := range exitsVotes {
+				app.Dao().DB().Unscoped().Delete(&v)
+			}
+
+			if choice != exitsChoice {
+				// vote opposite choice
+				create(choice)
+			} else {
+				// if choice is same then only un-vote
+				// reset choice to initial state
+				choice = ""
+			}
+		}
 
 		// sync
-		up, down := app.Dao().GetVoteNumUpDown(uint(targetID), voteTo)
-		save(up, down)
+		up, down := sync()
 
 		return common.RespData(c, ResponseVote{
-			Up:   up,
-			Down: down,
+			Up:     up,
+			Down:   down,
+			IsUp:   choice == "up",
+			IsDown: choice == "down",
 		})
 	}))
+}
+
+// VoteChoice is `up` or `down`
+func getVoteChoice(voteType string) string {
+	choice := strings.TrimPrefix(strings.TrimPrefix(voteType, "comment_"), "page_")
+	if choice != "up" && choice != "down" {
+		return ""
+	}
+	return choice
+}
+
+// VoteTarget is `comment` or `page`
+func getVoteTargetName(voteType string) string {
+	return strings.TrimSuffix(strings.TrimSuffix(voteType, "_up"), "_down")
+}
+
+func getExistsVotesByIP(dao *dao.Dao, ip string, targetName string, targetID uint) []entity.Vote {
+	var existsVotes []entity.Vote
+	dao.DB().Where("type LIKE ? AND target_id = ? AND ip = ?", targetName+"%", uint(targetID), ip).Find(&existsVotes)
+	return existsVotes
+}
+
+type createNewVoteParams struct {
+	ip         string
+	ua         string
+	userID     uint
+	targetName string
+	targetID   uint
+	choice     string
+}
+
+// Create new vote record
+func createVote(dao *dao.Dao, opts createNewVoteParams) error {
+	_, err := dao.NewVote(opts.targetID, entity.VoteType(opts.targetName+"_"+opts.choice), opts.userID, opts.ua, opts.ip)
+	return err
 }

--- a/server/server.go
+++ b/server/server.go
@@ -71,7 +71,7 @@ func Serve(app *core.App) (*fiber.App, error) {
 		h.CommentCreate(app, api)
 		h.CommentList(app, api)
 		h.CommentGet(app, api)
-		h.Vote(app, api)
+		h.VoteCreate(app, api)
 		h.PagePV(app, api)
 		h.Stat(app, api)
 		h.NotifyList(app, api)

--- a/ui/artalk/src/api/v2.ts
+++ b/ui/artalk/src/api/v2.ts
@@ -298,7 +298,7 @@ export interface HandlerParamsUserUpdate {
   receive_email: boolean
 }
 
-export interface HandlerParamsVote {
+export interface HandlerParamsVoteCreate {
   /** The user email */
   email?: string
   /** The username */
@@ -591,6 +591,8 @@ export interface HandlerResponseUserUpdate {
 
 export interface HandlerResponseVote {
   down: number
+  is_down: boolean
+  is_up: boolean
   up: number
 }
 
@@ -2533,12 +2535,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
- * @description Vote for a specific comment or page
+ * @description Create a new vote for a specific comment or page
  *
  * @tags Vote
- * @name Vote
- * @summary Vote
- * @request POST:/votes/{type}/{target_id}
+ * @name CreateVote
+ * @summary Create Vote
+ * @request POST:/votes/{target_name}/{target_id}/{choice}
  * @response `200` `HandlerResponseVote` OK
  * @response `403` `(HandlerMap & {
     msg?: string,
@@ -2553,10 +2555,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 
 })` Internal Server Error
  */
-    vote: (
-      type: 'comment_up' | 'comment_down' | 'page_up' | 'page_down',
+    createVote: (
+      targetName: 'comment' | 'page',
       targetId: number,
-      vote: HandlerParamsVote,
+      choice: 'up' | 'down',
+      vote: HandlerParamsVoteCreate,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -2565,7 +2568,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
           msg?: string
         }
       >({
-        path: `/votes/${type}/${targetId}`,
+        path: `/votes/${targetName}/${targetId}/${choice}`,
         method: 'POST',
         body: vote,
         type: ContentType.Json,

--- a/ui/artalk/src/comment/actions.ts
+++ b/ui/artalk/src/comment/actions.ts
@@ -20,12 +20,12 @@ export default class CommentActions {
   }
 
   /** 投票操作 */
-  public vote(type: 'up' | 'down') {
+  public vote(choice: 'up' | 'down') {
     const actionBtn =
-      type === 'up' ? this.comment.getRender().voteBtnUp : this.comment.getRender().voteBtnDown
+      choice === 'up' ? this.comment.getRender().voteBtnUp : this.comment.getRender().voteBtnDown
 
     this.getApi()
-      .votes.vote(`comment_${type}`, this.data.id, {
+      .votes.createVote('comment', this.data.id, choice, {
         ...this.getApi().getUserFields(),
       })
       .then((res) => {


### PR DESCRIPTION
The original `POST /votes/:type/:target_id` endpoint for creating votes has been updated to `POST /votes/:target_name/:target_id/:choice`. The `target_name` can be either `comment` or `page`, the `target_id` is a numeric value, and the `choice` can be `up` or `down`. (https://artalk.js.org/http-api.html#tag/Vote/operation/CreateVote)

The HTTP response now includes two additional fields: `is_up` and `is_down`, which indicate the user's current voting state. The `up` and `down` fields remain unchanged and continue to be of numeric type, ensuring backward compatibility with existing clients.

- Change vote endpoint to include `{target_name}` and `{choice}`
- Update vote logic to handle `up` and `down` choices
- Modify request data models and API interfaces for new vote structure
- Ensure backward compatibility with existing vote response data
- Improve vote handling and response structure

BREAKING CHANGE: Vote HTTP API endpoint have been updated. (See #997)

This is a prerequisite PR for #983.