### PR TITLE
feat(api/vote): add get vote status endpoint

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -3525,6 +3525,104 @@ const docTemplate = `{
                 }
             }
         },
+        "/votes/{target_name}/{target_id}": {
+            "get": {
+                "description": "Get vote status for a specific comment or page",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Vote"
+                ],
+                "summary": "Get Vote Status",
+                "operationId": "GetVote",
+                "parameters": [
+                    {
+                        "enum": [
+                            "comment",
+                            "page"
+                        ],
+                        "type": "string",
+                        "description": "The name of vote target",
+                        "name": "target_name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "The target comment or page ID",
+                        "name": "target_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handler.ResponseVote"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/handler.Map"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "msg": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/handler.Map"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "msg": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/handler.Map"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "msg": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
         "/votes/{target_name}/{target_id}/{choice}": {
             "post": {
                 "description": "Create a new vote for a specific comment or page",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -3518,6 +3518,104 @@
                 }
             }
         },
+        "/votes/{target_name}/{target_id}": {
+            "get": {
+                "description": "Get vote status for a specific comment or page",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Vote"
+                ],
+                "summary": "Get Vote Status",
+                "operationId": "GetVote",
+                "parameters": [
+                    {
+                        "enum": [
+                            "comment",
+                            "page"
+                        ],
+                        "type": "string",
+                        "description": "The name of vote target",
+                        "name": "target_name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "The target comment or page ID",
+                        "name": "target_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handler.ResponseVote"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/handler.Map"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "msg": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/handler.Map"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "msg": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/handler.Map"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "msg": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
         "/votes/{target_name}/{target_id}/{choice}": {
             "post": {
                 "description": "Create a new vote for a specific comment or page",

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -3284,6 +3284,63 @@ paths:
       summary: Get Version Info
       tags:
       - System
+  /votes/{target_name}/{target_id}:
+    get:
+      consumes:
+      - application/json
+      description: Get vote status for a specific comment or page
+      operationId: GetVote
+      parameters:
+      - description: The name of vote target
+        enum:
+        - comment
+        - page
+        in: path
+        name: target_name
+        required: true
+        type: string
+      - description: The target comment or page ID
+        in: path
+        name: target_id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handler.ResponseVote'
+        "403":
+          description: Forbidden
+          schema:
+            allOf:
+            - $ref: '#/definitions/handler.Map'
+            - properties:
+                msg:
+                  type: string
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            allOf:
+            - $ref: '#/definitions/handler.Map'
+            - properties:
+                msg:
+                  type: string
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/handler.Map'
+            - properties:
+                msg:
+                  type: string
+              type: object
+      summary: Get Vote Status
+      tags:
+      - Vote
   /votes/{target_name}/{target_id}/{choice}:
     post:
       consumes:

--- a/server/handler/base_test.go
+++ b/server/handler/base_test.go
@@ -7,6 +7,8 @@ import (
 
 func NewApiTestApp() (*test.TestApp, *fiber.App) {
 	app, _ := test.NewTestApp()
-	fiberApp := fiber.New()
+	fiberApp := fiber.New(fiber.Config{
+		ProxyHeader: "X-Forwarded-For",
+	})
 	return app, fiberApp
 }

--- a/server/handler/vote_test.go
+++ b/server/handler/vote_test.go
@@ -1,0 +1,185 @@
+package handler_test
+
+import (
+	"bytes"
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/artalkjs/artalk/v2/server/handler"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVote(t *testing.T) {
+	tests := []struct {
+		description  string
+		method       string
+		url          string
+		body         string
+		ip           string
+		expectedCode int
+		expectedBody func(t *testing.T, body string)
+	}{
+		{
+			description:  "Get comment vote status (original up)",
+			method:       "GET",
+			url:          "/votes/comment/1000",
+			expectedCode: 200,
+			ip:           "127.0.0.1",
+			expectedBody: func(t *testing.T, body string) {
+				assert.NotEmpty(t, body)
+				assert.Equal(t, `{"up":4,"down":2,"is_up":true,"is_down":false}`, body)
+			},
+		},
+		{
+			description:  "Get page vote status (original down)",
+			method:       "GET",
+			url:          "/votes/page/1001",
+			expectedCode: 200,
+			ip:           "127.0.0.1",
+			expectedBody: func(t *testing.T, body string) {
+				assert.NotEmpty(t, body)
+				assert.Equal(t, `{"up":1,"down":2,"is_up":false,"is_down":true}`, body)
+			},
+		},
+		{
+			description:  "Get comment vote status (original null)",
+			method:       "GET",
+			url:          "/votes/comment/1001",
+			expectedCode: 200,
+			ip:           "127.0.0.1",
+			expectedBody: func(t *testing.T, body string) {
+				assert.NotEmpty(t, body)
+				assert.Equal(t, `{"up":0,"down":0,"is_up":false,"is_down":false}`, body)
+			},
+		},
+		{
+			description:  "Get page vote status (original null)",
+			method:       "GET",
+			url:          "/votes/page/1002",
+			expectedCode: 200,
+			ip:           "127.0.0.1",
+			expectedBody: func(t *testing.T, body string) {
+				assert.NotEmpty(t, body)
+				assert.Equal(t, `{"up":0,"down":0,"is_up":false,"is_down":false}`, body)
+			},
+		},
+		{
+			description:  "Create comment up vote (original null, set to up)",
+			method:       "POST",
+			url:          "/votes/comment/1000/up",
+			body:         "{}",
+			expectedCode: 200,
+			ip:           "192.168.1.1",
+			expectedBody: func(t *testing.T, body string) {
+				assert.NotEmpty(t, body)
+				assert.Equal(t, `{"up":5,"down":2,"is_up":true,"is_down":false}`, body)
+			},
+		},
+		{
+			description:  "Create comment down vote (original null, set to down)",
+			method:       "POST",
+			url:          "/votes/comment/1000/down",
+			body:         "{}",
+			expectedCode: 200,
+			ip:           "192.168.1.2",
+			expectedBody: func(t *testing.T, body string) {
+				assert.NotEmpty(t, body)
+				assert.Equal(t, `{"up":4,"down":3,"is_up":false,"is_down":true}`, body)
+			},
+		},
+		{
+			description:  "Create page up vote (original null, set to up)",
+			method:       "POST",
+			url:          "/votes/page/1001/up",
+			body:         "{}",
+			expectedCode: 200,
+			ip:           "192.168.1.3",
+			expectedBody: func(t *testing.T, body string) {
+				assert.NotEmpty(t, body)
+				assert.Equal(t, `{"up":2,"down":2,"is_up":true,"is_down":false}`, body)
+			},
+		},
+		{
+			description:  "Create page down vote (original null, set to down)",
+			method:       "POST",
+			url:          "/votes/page/1001/down",
+			body:         "{}",
+			expectedCode: 200,
+			ip:           "192.168.1.4",
+			expectedBody: func(t *testing.T, body string) {
+				assert.NotEmpty(t, body)
+				assert.Equal(t, `{"up":1,"down":3,"is_up":false,"is_down":true}`, body)
+			},
+		},
+		{
+			description:  "Un-vote comment comment (original up, revoke up)",
+			method:       "POST",
+			url:          "/votes/comment/1000/up",
+			body:         "{}",
+			expectedCode: 200,
+			ip:           "127.0.0.1",
+			expectedBody: func(t *testing.T, body string) {
+				assert.NotEmpty(t, body)
+				assert.Equal(t, `{"up":3,"down":2,"is_up":false,"is_down":false}`, body)
+			},
+		},
+		{
+			description:  "Un-vote page comment (original down, revoke down)",
+			method:       "POST",
+			url:          "/votes/page/1001/down",
+			body:         "{}",
+			expectedCode: 200,
+			ip:           "127.0.0.1",
+			expectedBody: func(t *testing.T, body string) {
+				assert.NotEmpty(t, body)
+				assert.Equal(t, `{"up":1,"down":1,"is_up":false,"is_down":false}`, body)
+			},
+		},
+		{
+			description:  "Opposite-vote comment comment (original up, set to down)",
+			method:       "POST",
+			url:          "/votes/comment/1000/down",
+			body:         "{}",
+			expectedCode: 200,
+			ip:           "127.0.0.1",
+			expectedBody: func(t *testing.T, body string) {
+				assert.NotEmpty(t, body)
+				assert.Equal(t, `{"up":3,"down":3,"is_up":false,"is_down":true}`, body)
+			},
+		},
+		{
+			description:  "Opposite-vote page comment (original down, set to up)",
+			method:       "POST",
+			url:          "/votes/page/1001/up",
+			body:         "{}",
+			expectedCode: 200,
+			ip:           "127.0.0.1",
+			expectedBody: func(t *testing.T, body string) {
+				assert.NotEmpty(t, body)
+				assert.Equal(t, `{"up":2,"down":1,"is_up":true,"is_down":false}`, body)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			app, fiber := NewApiTestApp()
+			defer app.Cleanup()
+
+			handler.VoteGet(app.App, fiber)
+			handler.VoteCreate(app.App, fiber)
+
+			req := httptest.NewRequest(tt.method, tt.url, bytes.NewReader([]byte(tt.body)))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("X-Forwarded-For", tt.ip) // mock IP
+			resp, err := fiber.Test(req)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedCode, resp.StatusCode)
+
+			body, err := io.ReadAll(resp.Body)
+			assert.NoError(t, err)
+			tt.expectedBody(t, string(body))
+		})
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -71,6 +71,7 @@ func Serve(app *core.App) (*fiber.App, error) {
 		h.CommentCreate(app, api)
 		h.CommentList(app, api)
 		h.CommentGet(app, api)
+		h.VoteGet(app, api)
 		h.VoteCreate(app, api)
 		h.PagePV(app, api)
 		h.Stat(app, api)

--- a/test/fixtures/atk_votes.yml
+++ b/test/fixtures/atk_votes.yml
@@ -1,0 +1,51 @@
+# Comment 1000: 4 up, 2 down
+# Page    1001: 1 up, 2 down
+# The IP 127.0.0.1 had up-voted Comment 1000 and down-voted Page 1001.
+
+- id: 1000
+  target_id: 1000
+  type: comment_up
+  user_id: 1000
+  ip: 127.0.0.1
+
+- id: 1001
+  target_id: 1000
+  type: comment_up
+  user_id: 1001
+  ip: 192.168.1.11
+
+- id: 1002
+  target_id: 1000
+  type: comment_up
+  ip: 192.168.1.12
+
+- id: 1003
+  target_id: 1000
+  type: comment_up
+  ip: 192.168.1.13
+
+- id: 1004
+  target_id: 1000
+  type: comment_down
+  ip: 192.168.1.14
+
+- id: 1005
+  target_id: 1000
+  type: comment_down
+  ip: 192.168.1.15
+
+- id: 1006
+  target_id: 1001
+  type: page_down
+  user_id: 1000
+  ip: 127.0.0.1
+
+- id: 1007
+  target_id: 1001
+  type: page_up
+  ip: 192.168.1.17
+
+- id: 1008
+  target_id: 1001
+  type: page_down
+  ip: 192.168.1.18

--- a/ui/artalk/src/api/v2.ts
+++ b/ui/artalk/src/api/v2.ts
@@ -2535,6 +2535,41 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
+ * @description Get vote status for a specific comment or page
+ *
+ * @tags Vote
+ * @name GetVote
+ * @summary Get Vote Status
+ * @request GET:/votes/{target_name}/{target_id}
+ * @response `200` `HandlerResponseVote` OK
+ * @response `403` `(HandlerMap & {
+    msg?: string,
+
+})` Forbidden
+ * @response `404` `(HandlerMap & {
+    msg?: string,
+
+})` Not Found
+ * @response `500` `(HandlerMap & {
+    msg?: string,
+
+})` Internal Server Error
+ */
+    getVote: (targetName: 'comment' | 'page', targetId: number, params: RequestParams = {}) =>
+      this.request<
+        HandlerResponseVote,
+        HandlerMap & {
+          msg?: string
+        }
+      >({
+        path: `/votes/${targetName}/${targetId}`,
+        method: 'GET',
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
  * @description Create a new vote for a specific comment or page
  *
  * @tags Vote


### PR DESCRIPTION
A new HTTP API endpoint `GET /votes/:target_name/:target_id` is now available.

Response example:

```json
{"up":1,"down":1,"is_up":true,"is_down":false}
```

See https://artalk.js.org/http-api.html#tag/Vote/operation/GetVote

- Implement GET endpoint for retrieving vote status
- Add tests for vote functionality

Related to: #997

This is a prerequisite PR for #983.