### PR TITLE
chore(docs): corrected Docker build arg name for skipping ui build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,7 +224,7 @@ Replace `TAG` with the desired tag name (e.g., `latest`).
 If you have already built the frontend outside the Docker container, you can skip the frontend build process inside the container to speed up the build. Use the following command:
 
 ```sh
-docker build --build-arg SKIP_FRONTEND_BUILD=true -t artalk:latest .
+docker build --build-arg SKIP_UI_BUILD=true -t artalk:latest .
 ```
 
 For more details, refer to the `Dockerfile`.

--- a/docs/docs/zh/develop/contributing.md
+++ b/docs/docs/zh/develop/contributing.md
@@ -224,7 +224,7 @@ docker build -t artalk:TAG .
 如果你已经在 Docker 容器外部构建了前端，可以跳过容器内的前端构建过程以加快构建速度。使用以下命令：
 
 ```sh
-docker build --build-arg SKIP_FRONTEND_BUILD=true -t artalk:latest .
+docker build --build-arg SKIP_UI_BUILD=true -t artalk:latest .
 ```
 
 更多详细信息，请参考 `Dockerfile`。


### PR DESCRIPTION
- Fix SKIP_FRONTEND_BUILD to SKIP_UI_BUILD in documentation
- Update both English and Chinese contributing guides