### PR TITLE
新增两个界面配置开关，用于控制：左侧“评论数”、右侧“通知中心” 的显示控制 

### DIFF
--- a/conf/artalk.example.simple.yml
+++ b/conf/artalk.example.simple.yml
@@ -230,8 +230,8 @@ frontend:
   voteDown: false
   uaBadge: false
   listSort: true
-  commentCount: true
-  listHeader: true
+  commentCount: false
+  listHeader: false
   preview: true
   flatMode: auto
   darkMode: inherit

--- a/conf/artalk.example.simple.yml
+++ b/conf/artalk.example.simple.yml
@@ -230,6 +230,8 @@ frontend:
   voteDown: false
   uaBadge: false
   listSort: true
+  commentCount: true
+  listHeader: true
   preview: true
   flatMode: auto
   darkMode: inherit

--- a/conf/artalk.example.yml
+++ b/conf/artalk.example.yml
@@ -408,9 +408,9 @@ frontend:
   # Comment sorting
   listSort: true
   # Show comment count in list header
-  commentCount: true
+  commentCount: false
   # Show list header
-  listHeader: true
+  listHeader: false
   # Editor real-time preview
   preview: true
   # Flatten mode ["auto", true, false]

--- a/conf/artalk.example.yml
+++ b/conf/artalk.example.yml
@@ -407,6 +407,10 @@ frontend:
   uaBadge: false
   # Comment sorting
   listSort: true
+  # Show comment count in list header
+  commentCount: true
+  # Show list header
+  listHeader: true
   # Editor real-time preview
   preview: true
   # Flatten mode ["auto", true, false]

--- a/conf/artalk.example.zh-CN.yml
+++ b/conf/artalk.example.zh-CN.yml
@@ -416,9 +416,9 @@ frontend:
   # 评论排序功能
   listSort: true
   # 评论数
-  commentCount: true
+  commentCount: false
   # 通知中心
-  listHeader: true
+  listHeader: false
   # 编辑器实时预览功能
   preview: true
   # 平铺模式 ["auto", true, false]

--- a/conf/artalk.example.zh-CN.yml
+++ b/conf/artalk.example.zh-CN.yml
@@ -415,6 +415,10 @@ frontend:
   uaBadge: false
   # 评论排序功能
   listSort: true
+  # 评论数
+  commentCount: true
+  # 通知中心
+  listHeader: true
   # 编辑器实时预览功能
   preview: true
   # 平铺模式 ["auto", true, false]

--- a/conf/artalk.example.zh-TW.yml
+++ b/conf/artalk.example.zh-TW.yml
@@ -416,9 +416,9 @@ frontend:
   # 評論排序功能
   listSort: true
   # 評論數
-  commentCount: true
+  commentCount: false
   # 通知中心
-  listHeader: true
+  listHeader: false
   # 編輯器實時預覽功能
   preview: true
   # 平鋪模式 ["auto", true, false]

--- a/conf/artalk.example.zh-TW.yml
+++ b/conf/artalk.example.zh-TW.yml
@@ -415,6 +415,10 @@ frontend:
   uaBadge: false
   # 評論排序功能
   listSort: true
+  # 評論數
+  commentCount: true
+  # 通知中心
+  listHeader: true
   # 編輯器實時預覽功能
   preview: true
   # 平鋪模式 ["auto", true, false]

--- a/ui/artalk/src/defaults.ts
+++ b/ui/artalk/src/defaults.ts
@@ -28,6 +28,8 @@ export const Defaults: Readonly<RequiredExcept<Config, ExcludedKeys>> = {
   uaBadge: ARTALK_LITE ? false : true,
   listSort: true,
   preview: ARTALK_LITE ? false : true,
+  commentCount: true,
+  listHeader: true,
   countEl: '.artalk-comment-count',
   pvEl: '.artalk-pv-count',
   statPageKeyAttr: 'data-page-key',

--- a/ui/artalk/src/list/list.ts
+++ b/ui/artalk/src/list/list.ts
@@ -41,7 +41,22 @@ export class List implements IList {
 
     // Init base element
     this.$el = Utils.createElement(ListHTML)
+    if (this.opts.getConf().get().listHeader === false) {
+      const $header = this.$el.querySelector<HTMLElement>('.atk-list-header')
+      if ($header) $header.style.display = 'none'
+      this.$el.classList.add('atk-no-header')
+    }
     this.$commentsWrap = this.$el.querySelector('.atk-list-comments-wrap')!
+
+    // Watch config changes for list header toggle
+    this.opts
+      .getConf()
+      .watchConf(['listHeader'], (conf) => {
+        const $header = this.$el.querySelector<HTMLElement>('.atk-list-header')
+        if ($header) $header.style.display = conf.listHeader === false ? 'none' : ''
+        if (conf.listHeader === false) this.$el.classList.add('atk-no-header')
+        else this.$el.classList.remove('atk-no-header')
+      })
 
     // Init paginator
     initListPaginatorFunc({

--- a/ui/artalk/src/plugins/list/count.ts
+++ b/ui/artalk/src/plugins/list/count.ts
@@ -4,6 +4,22 @@ import $t from '@/i18n'
 
 export const Count: ArtalkPlugin = (ctx) => {
   const list = ctx.inject('list')
+  const conf = ctx.inject('config').get()
+
+  if (conf.commentCount === false) {
+    const $wrap = list.getEl().querySelector<HTMLElement>('.atk-comment-count')
+    if ($wrap) $wrap.style.display = 'none'
+  } else {
+    const $wrap = list.getEl().querySelector<HTMLElement>('.atk-comment-count')
+    if ($wrap) $wrap.style.display = ''
+  }
+
+  // react to remote config updates
+  ctx.inject('config').watchConf(['commentCount'], (c) => {
+    const $wrap = list.getEl().querySelector<HTMLElement>('.atk-comment-count')
+    if (!$wrap) return
+    $wrap.style.display = c.commentCount === false ? 'none' : ''
+  })
 
   const refreshCountNumEl = () => {
     const $count = list.getEl().querySelector('.atk-comment-count .atk-text')

--- a/ui/artalk/src/style/list.scss
+++ b/ui/artalk/src/style/list.scss
@@ -127,6 +127,7 @@
 
   & > .atk-list-body {
     min-height: 150px;
+    padding-top: 0;
 
     .atk-list-comments-wrap {
       .atk-main-editor {
@@ -154,6 +155,10 @@
       }
     }
   }
+}
+
+.artalk > .atk-list.atk-no-header > .atk-list-body {
+  padding-top: 15px;
 }
 
 .atk-list-no-comment {

--- a/ui/artalk/src/types/config.ts
+++ b/ui/artalk/src/types/config.ts
@@ -97,6 +97,12 @@ export interface Config {
   /** Preview feature for comments */
   preview: boolean
 
+  /** Show comment count in list header */
+  commentCount: boolean
+
+  /** Show list header */
+  listHeader: boolean
+
   /** Selector for the element binding to the comment count */
   countEl: string
 


### PR DESCRIPTION
- 新增两个前端配置开关，用于控制列表头部显示：
  - frontend.commentCount ：左侧“评论数”显示控制
  - frontend.listHeader ：右侧“通知中心”显示控制
    改动点
- 新增配置字段
  - 类型定义： ui/artalk/src/types/config.ts:100-105
  - 默认值： ui/artalk/src/defaults.ts:31-33 （均为 true ）
- 模板文件
  - conf/artalk.example.yml:410-413
  - conf/artalk.example.simple.yml:233-235
  - conf/artalk.example.zh-CN.yml:418-421
  - conf/artalk.example.zh-TW.yml:418-421
- 前端逻辑
  - 隐藏头部： ui/artalk/src/list/list.ts:44-48,52-59
  - 隐藏评论数： ui/artalk/src/plugins/list/count.ts:9-15,18-22
  - 两者都隐藏时，自动加顶部留白，避免评论贴得过近： ui/artalk/src/style/list.scss:164-166
  - 默认不改变现有行为（默认值为 true ）