### PR TITLE
feat: add 'ugc' to link rel attributes

### DIFF
--- a/ui/artalk/src/comment/renders/avatar.ts
+++ b/ui/artalk/src/comment/renders/avatar.ts
@@ -13,7 +13,7 @@ export default function renderAvatar(r: Render) {
 
   if (r.data.link) {
     const $avatarA = Utils.createElement<HTMLLinkElement>(
-      '<a target="_blank" rel="noreferrer noopener nofollow"></a>',
+      '<a target="_blank" rel="noreferrer noopener nofollow ugc"></a>',
     )
     $avatarA.href = Utils.isValidURL(r.data.link) ? r.data.link : `https://${r.data.link}`
     $avatarA.append($avatarImg)

--- a/ui/artalk/src/comment/renders/header.ts
+++ b/ui/artalk/src/comment/renders/header.ts
@@ -21,7 +21,7 @@ function renderNick(r: Render) {
 
   if (r.data.link) {
     const $nickA = Utils.createElement<HTMLLinkElement>(
-      '<a target="_blank" rel="noreferrer noopener nofollow"></a>',
+      '<a target="_blank" rel="noreferrer noopener nofollow ugc"></a>',
     )
     $nickA.innerText = r.data.nick
     $nickA.href = Utils.isValidURL(r.data.link) ? r.data.link : `https://${r.data.link}`

--- a/ui/artalk/src/lib/marked-renderer.ts
+++ b/ui/artalk/src/lib/marked-renderer.ts
@@ -27,7 +27,7 @@ const markedLinkRenderer =
     const html = orgLinkRenderer.call(renderer, args)
     return html.replace(
       /^<a /,
-      `<a target="_blank" ${!isSameOriginLink ? `rel="noreferrer noopener nofollow"` : ''} `,
+      `<a target="_blank" ${!isSameOriginLink ? `rel="noreferrer noopener nofollow ugc"` : ''} `,
     )
   }
 


### PR DESCRIPTION
- `+ ugc` 符合最新语义（Google 自 2019） 

我调查了下其他的
- twikoo 是 noopener noreferrer nofollow ugc
- waline 是 ugc nofollow noreferrer noopener
- valine 是 noopener

相关文档：
- nofollow 和 ugc 一起用以保证兼容性：https://developers.google.com/search/blog/2019/09/evolving-nofollow-new-ways-to-identify?hl=zh-cn#can-i-use-more-than-one-rel-value-on-a-link
- 几个用于出站链接的 rel 值（sponsored，ugc，nofollow）介绍：https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links?hl=zh-cn 
- https://www.iana.org/assignments/link-relations/link-relations.xhtml