### PR TITLE
feat(emoticons): support url for image emoticon groups

### DIFF
--- a/ui/artalk/src/plugins/editor/emoticons.ts
+++ b/ui/artalk/src/plugins/editor/emoticons.ts
@@ -139,8 +139,22 @@ export default class Emoticons extends EditorPlugin {
 
     this.solveNullKey(data)
     this.solveSameKey(data)
+    this.applyUrl(data)
 
     return data
+  }
+
+  /** 应用分组 Url，将相对 val 拼接为完整 URL */
+  private applyUrl(data: EmoticonGrpData[]) {
+    data.forEach((grp) => {
+      if (grp.type !== 'image' || !grp.url) return
+      const base = grp.url
+      grp.items.forEach((item) => {
+        if (!item.val) return
+        if (/^https?:\/\//i.test(item.val)) return
+        item.val = base + item.val
+      })
+    })
   }
 
   /** 远程加载 */

--- a/ui/artalk/src/types/data.ts
+++ b/ui/artalk/src/types/data.ts
@@ -189,6 +189,7 @@ export interface NotifyData {
 export type EmoticonGrpData = {
   name: string
   type: 'emoticon' | 'image' | 'emoji'
+  url?: string
   items: { key: string; val: string }[]
 }
 


### PR DESCRIPTION
Add optional `url` field to emoticon group data. When present, each item's `val` is prepended with `url` to form the full URL. Values already starting with `http://` or `https://` are left unchanged. This reduces repetition in emoticon JSON files.

Before:
```json
{
  "name": "微信表情",
  "type": "image",
  "items": [
    { "key": "666", "val": "https://cos.lhasa.icu/dist/emoji/666.png" },
    { "key": "OK", "val": "https://cos.lhasa.icu/dist/emoji/OK.png" }
  ]
}
After:
{
  "name": "微信表情",
  "type": "image",
  "url": "https://cos.lhasa.icu/dist/emoji/",
  "items": [
    { "key": "666", "val": "666.png" },
    { "key": "OK", "val": "OK.png" }
  ]
}