### PR TITLE
fix(ui): avoid timezone-ambiguous comment timestamps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+artalk
 
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/docs/docs/en/guide/backend/email.md
+++ b/docs/docs/en/guide/backend/email.md
@@ -117,6 +117,8 @@ Variables follow the "Mustache" syntax, outputting a variable with `double brace
 {{comment.content_raw}}
 {{comment.date}}
 {{comment.datetime}}
+{{comment.date_unix}}
+{{comment.date_utc}}
 {{comment.email}}
 {{comment.email_encrypted}}
 {{comment.id}}
@@ -155,6 +157,8 @@ Variables follow the "Mustache" syntax, outputting a variable with `double brace
 {{parent_comment.content_raw}}
 {{parent_comment.date}}
 {{parent_comment.datetime}}
+{{parent_comment.date_unix}}
+{{parent_comment.date_utc}}
 {{parent_comment.email}}
 {{parent_comment.email_encrypted}}
 {{parent_comment.id}}
@@ -210,6 +214,8 @@ Variables follow the "Mustache" syntax, outputting a variable with `double brace
   "comment.content_raw": "Replier's content",
   "comment.date": "2021-11-22",
   "comment.datetime": "2021-11-22 22:22:42",
+  "comment.date_unix": 1637590962,
+  "comment.date_utc": "2021-11-22T14:22:42Z",
   "comment.email": "replyer@example.com",
   "comment.email_encrypted": "249898bd50e0febc5799485cf10b345a",
   "comment.id": 8100,
@@ -247,6 +253,8 @@ Variables follow the "Mustache" syntax, outputting a variable with `double brace
   "parent_comment.content_raw": "Test content",
   "parent_comment.date": "2021-11-22",
   "parent_comment.datetime": "2021-11-22 22:21:17",
+  "parent_comment.date_unix": 1637590877,
+  "parent_comment.date_utc": "2021-11-22T14:21:17Z",
   "parent_comment.email": "test@example.com",
   "parent_comment.email_encrypted": "55502f40dc8b7c769880b10874abc9d0",
   "parent_comment.id": 8099,

--- a/docs/docs/zh/guide/backend/email.md
+++ b/docs/docs/zh/guide/backend/email.md
@@ -117,6 +117,8 @@ email:
 {{comment.content_raw}}
 {{comment.date}}
 {{comment.datetime}}
+{{comment.date_unix}}
+{{comment.date_utc}}
 {{comment.email}}
 {{comment.email_encrypted}}
 {{comment.id}}
@@ -155,6 +157,8 @@ email:
 {{parent_comment.content_raw}}
 {{parent_comment.date}}
 {{parent_comment.datetime}}
+{{parent_comment.date_unix}}
+{{parent_comment.date_utc}}
 {{parent_comment.email}}
 {{parent_comment.email_encrypted}}
 {{parent_comment.id}}
@@ -210,6 +214,8 @@ email:
   "comment.content_raw": "回复者内容",
   "comment.date": "2021-11-22",
   "comment.datetime": "2021-11-22 22:22:42",
+  "comment.date_unix": 1637590962,
+  "comment.date_utc": "2021-11-22T14:22:42Z",
   "comment.email": "replyer@example.com",
   "comment.email_encrypted": "249898bd50e0febc5799485cf10b345a",
   "comment.id": 8100,
@@ -247,6 +253,8 @@ email:
   "parent_comment.content_raw": "测试内容",
   "parent_comment.date": "2021-11-22",
   "parent_comment.datetime": "2021-11-22 22:21:17",
+  "parent_comment.date_unix": 1637590877,
+  "parent_comment.date_utc": "2021-11-22T14:21:17Z",
   "parent_comment.email": "test@example.com",
   "parent_comment.email_encrypted": "55502f40dc8b7c769880b10874abc9d0",
   "parent_comment.id": 8099,

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -3984,6 +3984,8 @@ const docTemplate = `{
                 "content",
                 "content_marked",
                 "date",
+                "date_unix",
+                "date_utc",
                 "email_encrypted",
                 "id",
                 "is_allow_reply",
@@ -4017,6 +4019,12 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "date": {
+                    "type": "string"
+                },
+                "date_unix": {
+                    "type": "integer"
+                },
+                "date_utc": {
                     "type": "string"
                 },
                 "email_encrypted": {
@@ -4114,6 +4122,8 @@ const docTemplate = `{
             "required": [
                 "admin_only",
                 "date",
+                "date_unix",
+                "date_utc",
                 "id",
                 "key",
                 "pv",
@@ -4128,6 +4138,12 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "date": {
+                    "type": "string"
+                },
+                "date_unix": {
+                    "type": "integer"
+                },
+                "date_utc": {
                     "type": "string"
                 },
                 "id": {
@@ -4897,6 +4913,8 @@ const docTemplate = `{
                 "content",
                 "content_marked",
                 "date",
+                "date_unix",
+                "date_utc",
                 "email_encrypted",
                 "id",
                 "is_allow_reply",
@@ -4930,6 +4948,12 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "date": {
+                    "type": "string"
+                },
+                "date_unix": {
+                    "type": "integer"
+                },
+                "date_utc": {
                     "type": "string"
                 },
                 "email_encrypted": {
@@ -5049,6 +5073,8 @@ const docTemplate = `{
                 "content",
                 "content_marked",
                 "date",
+                "date_unix",
+                "date_utc",
                 "email_encrypted",
                 "id",
                 "is_allow_reply",
@@ -5082,6 +5108,12 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "date": {
+                    "type": "string"
+                },
+                "date_unix": {
+                    "type": "integer"
+                },
+                "date_utc": {
                     "type": "string"
                 },
                 "email_encrypted": {
@@ -5201,6 +5233,8 @@ const docTemplate = `{
             "required": [
                 "admin_only",
                 "date",
+                "date_unix",
+                "date_utc",
                 "id",
                 "key",
                 "pv",
@@ -5215,6 +5249,12 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "date": {
+                    "type": "string"
+                },
+                "date_unix": {
+                    "type": "integer"
+                },
+                "date_utc": {
                     "type": "string"
                 },
                 "id": {
@@ -5304,6 +5344,8 @@ const docTemplate = `{
             "required": [
                 "admin_only",
                 "date",
+                "date_unix",
+                "date_utc",
                 "id",
                 "key",
                 "pv",
@@ -5318,6 +5360,12 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "date": {
+                    "type": "string"
+                },
+                "date_unix": {
+                    "type": "integer"
+                },
+                "date_utc": {
                     "type": "string"
                 },
                 "id": {

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -3977,6 +3977,8 @@
                 "content",
                 "content_marked",
                 "date",
+                "date_unix",
+                "date_utc",
                 "email_encrypted",
                 "id",
                 "is_allow_reply",
@@ -4010,6 +4012,12 @@
                     "type": "string"
                 },
                 "date": {
+                    "type": "string"
+                },
+                "date_unix": {
+                    "type": "integer"
+                },
+                "date_utc": {
                     "type": "string"
                 },
                 "email_encrypted": {
@@ -4107,6 +4115,8 @@
             "required": [
                 "admin_only",
                 "date",
+                "date_unix",
+                "date_utc",
                 "id",
                 "key",
                 "pv",
@@ -4121,6 +4131,12 @@
                     "type": "boolean"
                 },
                 "date": {
+                    "type": "string"
+                },
+                "date_unix": {
+                    "type": "integer"
+                },
+                "date_utc": {
                     "type": "string"
                 },
                 "id": {
@@ -4890,6 +4906,8 @@
                 "content",
                 "content_marked",
                 "date",
+                "date_unix",
+                "date_utc",
                 "email_encrypted",
                 "id",
                 "is_allow_reply",
@@ -4923,6 +4941,12 @@
                     "type": "string"
                 },
                 "date": {
+                    "type": "string"
+                },
+                "date_unix": {
+                    "type": "integer"
+                },
+                "date_utc": {
                     "type": "string"
                 },
                 "email_encrypted": {
@@ -5042,6 +5066,8 @@
                 "content",
                 "content_marked",
                 "date",
+                "date_unix",
+                "date_utc",
                 "email_encrypted",
                 "id",
                 "is_allow_reply",
@@ -5075,6 +5101,12 @@
                     "type": "string"
                 },
                 "date": {
+                    "type": "string"
+                },
+                "date_unix": {
+                    "type": "integer"
+                },
+                "date_utc": {
                     "type": "string"
                 },
                 "email_encrypted": {
@@ -5194,6 +5226,8 @@
             "required": [
                 "admin_only",
                 "date",
+                "date_unix",
+                "date_utc",
                 "id",
                 "key",
                 "pv",
@@ -5208,6 +5242,12 @@
                     "type": "boolean"
                 },
                 "date": {
+                    "type": "string"
+                },
+                "date_unix": {
+                    "type": "integer"
+                },
+                "date_utc": {
                     "type": "string"
                 },
                 "id": {
@@ -5297,6 +5337,8 @@
             "required": [
                 "admin_only",
                 "date",
+                "date_unix",
+                "date_utc",
                 "id",
                 "key",
                 "pv",
@@ -5311,6 +5353,12 @@
                     "type": "boolean"
                 },
                 "date": {
+                    "type": "string"
+                },
+                "date_unix": {
+                    "type": "integer"
+                },
+                "date_utc": {
                     "type": "string"
                 },
                 "id": {

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -61,6 +61,10 @@ definitions:
         type: string
       date:
         type: string
+      date_unix:
+        type: integer
+      date_utc:
+        type: string
       email_encrypted:
         type: string
       id:
@@ -105,6 +109,8 @@ definitions:
     - content
     - content_marked
     - date
+    - date_unix
+    - date_utc
     - email_encrypted
     - id
     - is_allow_reply
@@ -152,6 +158,10 @@ definitions:
         type: boolean
       date:
         type: string
+      date_unix:
+        type: integer
+      date_utc:
+        type: string
       id:
         type: integer
       key:
@@ -171,6 +181,8 @@ definitions:
     required:
     - admin_only
     - date
+    - date_unix
+    - date_utc
     - id
     - key
     - pv
@@ -713,6 +725,10 @@ definitions:
         type: string
       date:
         type: string
+      date_unix:
+        type: integer
+      date_utc:
+        type: string
       email_encrypted:
         type: string
       id:
@@ -757,6 +773,8 @@ definitions:
     - content
     - content_marked
     - date
+    - date_unix
+    - date_utc
     - email_encrypted
     - id
     - is_allow_reply
@@ -819,6 +837,10 @@ definitions:
         type: string
       date:
         type: string
+      date_unix:
+        type: integer
+      date_utc:
+        type: string
       email_encrypted:
         type: string
       id:
@@ -863,6 +885,8 @@ definitions:
     - content
     - content_marked
     - date
+    - date_unix
+    - date_utc
     - email_encrypted
     - id
     - is_allow_reply
@@ -924,6 +948,10 @@ definitions:
         type: boolean
       date:
         type: string
+      date_unix:
+        type: integer
+      date_utc:
+        type: string
       id:
         type: integer
       key:
@@ -943,6 +971,8 @@ definitions:
     required:
     - admin_only
     - date
+    - date_unix
+    - date_utc
     - id
     - key
     - pv
@@ -997,6 +1027,10 @@ definitions:
         type: boolean
       date:
         type: string
+      date_unix:
+        type: integer
+      date_utc:
+        type: string
       id:
         type: integer
       key:
@@ -1016,6 +1050,8 @@ definitions:
     required:
     - admin_only
     - date
+    - date_unix
+    - date_utc
     - id
     - key
     - pv

--- a/internal/dao/cook.go
+++ b/internal/dao/cook.go
@@ -4,6 +4,7 @@ package dao
 
 import (
 	"strings"
+	"time"
 
 	"github.com/artalkjs/artalk/v2/internal/entity"
 	"github.com/artalkjs/artalk/v2/internal/utils"
@@ -11,6 +12,20 @@ import (
 )
 
 const CommonDateTimeFormat = "2006-01-02 15:04:05"
+
+type cookedTime struct {
+	Legacy string
+	Unix   int64
+	UTC    string
+}
+
+func cookTime(t time.Time) cookedTime {
+	return cookedTime{
+		Legacy: t.Local().Format(CommonDateTimeFormat),
+		Unix:   t.Unix(),
+		UTC:    t.UTC().Format(time.RFC3339),
+	}
+}
 
 // TODO: (refactor) remove this global variable
 var getCommentEmailHash = func(email string) string { return utils.GetMD5Hash(strings.ToLower(email)) }
@@ -42,6 +57,7 @@ func (dao *Dao) CookComment(c *entity.Comment) entity.CookedComment {
 	}
 
 	markedContent, _ := utils.Marked(c.Content)
+	createdAt := cookTime(c.CreatedAt)
 
 	return entity.CookedComment{
 		ID:             c.ID,
@@ -52,7 +68,9 @@ func (dao *Dao) CookComment(c *entity.Comment) entity.CookedComment {
 		EmailEncrypted: getCommentEmailHash(user.Email),
 		Link:           user.Link,
 		UA:             c.UA,
-		Date:           c.CreatedAt.Local().Format(CommonDateTimeFormat),
+		Date:           createdAt.Legacy,
+		DateUnix:       createdAt.Unix,
+		DateUTC:        createdAt.UTC,
 		IsCollapsed:    c.IsCollapsed,
 		IsPending:      c.IsPending,
 		IsPinned:       c.IsPinned,
@@ -84,6 +102,7 @@ func (dao *Dao) CookCommentForEmail(c *entity.Comment) entity.CookedCommentForEm
 	page := dao.FetchPageForComment(c)
 	site := dao.FetchSiteForComment(c)
 	content, _ := utils.Marked(c.Content)
+	createdAt := cookTime(c.CreatedAt)
 
 	return entity.CookedCommentForEmail{
 		Content:    content,
@@ -91,7 +110,7 @@ func (dao *Dao) CookCommentForEmail(c *entity.Comment) entity.CookedCommentForEm
 		Nick:       user.Name,
 		Email:      user.Email,
 		IP:         c.IP,
-		Datetime:   c.CreatedAt.Local().Format(CommonDateTimeFormat),
+		Datetime:   createdAt.Legacy,
 		Date:       c.CreatedAt.Local().Format("2006-01-02"),
 		Time:       c.CreatedAt.Local().Format("15:04:05"),
 		PageKey:    c.PageKey,
@@ -104,6 +123,8 @@ func (dao *Dao) CookCommentForEmail(c *entity.Comment) entity.CookedCommentForEm
 			EmailEncrypted: getCommentEmailHash(user.Email),
 			Link:           user.Link,
 			UA:             c.UA,
+			DateUnix:       createdAt.Unix,
+			DateUTC:        createdAt.UTC,
 			IsCollapsed:    c.IsCollapsed,
 			IsPending:      c.IsPending,
 			IsPinned:       c.IsPinned,
@@ -120,6 +141,8 @@ func (dao *Dao) CookCommentForEmail(c *entity.Comment) entity.CookedCommentForEm
 // ===============
 
 func (dao *Dao) CookPage(p *entity.Page) entity.CookedPage {
+	createdAt := cookTime(p.CreatedAt)
+
 	return entity.CookedPage{
 		ID:        p.ID,
 		AdminOnly: p.AdminOnly,
@@ -130,7 +153,9 @@ func (dao *Dao) CookPage(p *entity.Page) entity.CookedPage {
 		VoteUp:    p.VoteUp,
 		VoteDown:  p.VoteDown,
 		PV:        p.PV,
-		Date:      p.CreatedAt.Local().Format(CommonDateTimeFormat),
+		Date:      createdAt.Legacy,
+		DateUnix:  createdAt.Unix,
+		DateUTC:   createdAt.UTC,
 	}
 }
 

--- a/internal/entity/comment_cooked.go
+++ b/internal/entity/comment_cooked.go
@@ -10,6 +10,8 @@ type CookedComment struct {
 	Link           string `json:"link"`
 	UA             string `json:"ua"`
 	Date           string `json:"date"`
+	DateUnix       int64  `json:"date_unix"`
+	DateUTC        string `json:"date_utc"`
 	IsCollapsed    bool   `json:"is_collapsed"`
 	IsPending      bool   `json:"is_pending"`
 	IsPinned       bool   `json:"is_pinned"`

--- a/internal/entity/page_cooked.go
+++ b/internal/entity/page_cooked.go
@@ -11,4 +11,6 @@ type CookedPage struct {
 	VoteDown  int    `json:"vote_down"`
 	PV        int    `json:"pv"`
 	Date      string `json:"date"`
+	DateUnix  int64  `json:"date_unix"`
+	DateUTC   string `json:"date_utc"`
 }

--- a/ui/artalk/src/api/v2.ts
+++ b/ui/artalk/src/api/v2.ts
@@ -43,6 +43,8 @@ export interface EntityCookedComment {
   content: string
   content_marked: string
   date: string
+  date_unix: number
+  date_utc: string
   email_encrypted: string
   id: number
   ip_region?: string
@@ -76,6 +78,8 @@ export interface EntityCookedNotify {
 export interface EntityCookedPage {
   admin_only: boolean
   date: string
+  date_unix: number
+  date_utc: string
   id: number
   key: string
   pv: number
@@ -373,6 +377,8 @@ export interface HandlerResponseCommentCreate {
   content: string
   content_marked: string
   date: string
+  date_unix: number
+  date_utc: string
   email_encrypted: string
   id: number
   ip_region?: string
@@ -414,6 +420,8 @@ export interface HandlerResponseCommentUpdate {
   content: string
   content_marked: string
   date: string
+  date_unix: number
+  date_utc: string
   email_encrypted: string
   id: number
   ip_region?: string
@@ -455,6 +463,8 @@ export interface HandlerResponseNotifyList {
 export interface HandlerResponsePageFetch {
   admin_only: boolean
   date: string
+  date_unix: number
+  date_utc: string
   id: number
   key: string
   pv: number
@@ -488,6 +498,8 @@ export interface HandlerResponsePagePV {
 export interface HandlerResponsePageUpdate {
   admin_only: boolean
   date: string
+  date_unix: number
+  date_utc: string
   id: number
   key: string
   pv: number

--- a/ui/artalk/src/comment/comment-node.ts
+++ b/ui/artalk/src/comment/comment-node.ts
@@ -215,13 +215,13 @@ export default class CommentNode {
   }
 
   /** Get the parsed comment creation time. */
-  public getDate() {
+  public getCreatedAt() {
     return Utils.parseDate(this.data)
   }
 
   /** 获取格式化后的日期 */
   public getDateFormatted() {
-    const date = this.getDate()
+    const date = this.getCreatedAt()
     return this.opts.dateFormatter?.(date) || Utils.timeAgo(date, $t)
   }
 

--- a/ui/artalk/src/comment/comment-node.ts
+++ b/ui/artalk/src/comment/comment-node.ts
@@ -51,7 +51,7 @@ export default class CommentNode {
   constructor(data: CommentData, opts: CommentOptions) {
     this.opts = opts
     this.data = { ...data }
-    this.data.date = this.data.date.replace(/-/g, '/') // 解决 Safari 日期解析 NaN 问题
+    this.data.date = this.data.date.replace(/-/g, '/')
 
     this.parent = null
     this.nestCurt = 1 // 现在已嵌套 n 层
@@ -214,9 +214,14 @@ export default class CommentNode {
     return marked(this.data.content)
   }
 
+  /** Get the parsed comment creation time. */
+  public getDate() {
+    return Utils.parseDate(this.data)
+  }
+
   /** 获取格式化后的日期 */
   public getDateFormatted() {
-    const date = new Date(this.data.date)
+    const date = this.getDate()
     return this.opts.dateFormatter?.(date) || Utils.timeAgo(date, $t)
   }
 

--- a/ui/artalk/src/comment/renders/header.ts
+++ b/ui/artalk/src/comment/renders/header.ts
@@ -58,7 +58,7 @@ function renderVerifyBadge(ctx: Render) {
 function renderDate(ctx: Render) {
   const $date = ctx.$el.querySelector<HTMLElement>('.atk-date')!
   $date.innerText = ctx.comment.getDateFormatted()
-  $date.setAttribute('data-atk-comment-date', String(+ctx.comment.getDate()))
+  $date.setAttribute('data-atk-comment-date', String(+ctx.comment.getCreatedAt()))
 }
 
 function renderUABadge(ctx: Render) {

--- a/ui/artalk/src/comment/renders/header.ts
+++ b/ui/artalk/src/comment/renders/header.ts
@@ -58,7 +58,7 @@ function renderVerifyBadge(ctx: Render) {
 function renderDate(ctx: Render) {
   const $date = ctx.$el.querySelector<HTMLElement>('.atk-date')!
   $date.innerText = ctx.comment.getDateFormatted()
-  $date.setAttribute('data-atk-comment-date', String(+new Date(ctx.data.date)))
+  $date.setAttribute('data-atk-comment-date', String(+ctx.comment.getDate()))
 }
 
 function renderUABadge(ctx: Render) {

--- a/ui/artalk/src/lib/utils.ts
+++ b/ui/artalk/src/lib/utils.ts
@@ -64,10 +64,6 @@ export interface TimestampedDateInput {
   date_utc?: string
 }
 
-function isValidDate(date: Date) {
-  return !Number.isNaN(date.getTime())
-}
-
 /**
  * Parses timestamp fields returned by Artalk APIs.
  *
@@ -77,12 +73,12 @@ function isValidDate(date: Date) {
 export function parseDate(input: TimestampedDateInput) {
   if (typeof input.date_unix === 'number' && Number.isFinite(input.date_unix)) {
     const unixDate = new Date(input.date_unix * 1000)
-    if (isValidDate(unixDate)) return unixDate
+    if (!Number.isNaN(unixDate.getTime())) return unixDate
   }
 
   if (input.date_utc) {
     const utcDate = new Date(input.date_utc)
-    if (isValidDate(utcDate)) return utcDate
+    if (!Number.isNaN(utcDate.getTime())) return utcDate
   }
 
   return new Date((input.date || '').replace(/-/g, '/'))

--- a/ui/artalk/src/lib/utils.ts
+++ b/ui/artalk/src/lib/utils.ts
@@ -58,6 +58,36 @@ export function padWithZeros(vNumber: number, width: number) {
   return numAsString
 }
 
+export interface TimestampedDateInput {
+  date?: string
+  date_unix?: number
+  date_utc?: string
+}
+
+function isValidDate(date: Date) {
+  return !Number.isNaN(date.getTime())
+}
+
+/**
+ * Parses timestamp fields returned by Artalk APIs.
+ *
+ * `date_unix` and `date_utc` are timezone-safe and take precedence over the legacy
+ * timezone-less `date` field, which is only used for backward compatibility.
+ */
+export function parseDate(input: TimestampedDateInput) {
+  if (typeof input.date_unix === 'number' && Number.isFinite(input.date_unix)) {
+    const unixDate = new Date(input.date_unix * 1000)
+    if (isValidDate(unixDate)) return unixDate
+  }
+
+  if (input.date_utc) {
+    const utcDate = new Date(input.date_utc)
+    if (isValidDate(utcDate)) return utcDate
+  }
+
+  return new Date((input.date || '').replace(/-/g, '/'))
+}
+
 export function dateFormat(date: Date) {
   const vDay = padWithZeros(date.getDate(), 2)
   const vMonth = padWithZeros(date.getMonth() + 1, 2)

--- a/ui/artalk/src/list/nest.ts
+++ b/ui/artalk/src/list/nest.ts
@@ -1,4 +1,5 @@
 import type { CommentData } from '@/types'
+import { parseDate } from '@/lib/utils'
 
 export type CommentNode = {
   id: number
@@ -51,8 +52,8 @@ export function makeNestCommentNodeList(
   // 排序
   const sortFunc = (a: CommentNode, b: CommentNode): number => {
     let v = a.id - b.id
-    if (sortBy === 'DATE_ASC') v = +new Date(a.comment.date) - +new Date(b.comment.date)
-    else if (sortBy === 'DATE_DESC') v = +new Date(b.comment.date) - +new Date(a.comment.date)
+    if (sortBy === 'DATE_ASC') v = +parseDate(a.comment) - +parseDate(b.comment)
+    else if (sortBy === 'DATE_DESC') v = +parseDate(b.comment) - +parseDate(a.comment)
     else if (sortBy === 'SRC_INDEX') v = srcData.indexOf(a.comment) - srcData.indexOf(b.comment)
     else if (sortBy === 'VOTE_UP_DESC') v = b.comment.vote_up - a.comment.vote_up
     return v

--- a/ui/artalk/src/types/data.ts
+++ b/ui/artalk/src/types/data.ts
@@ -26,6 +26,12 @@ export interface CommentData {
   /** 评论日期 */
   date: string
 
+  /** 评论日期 Unix 秒级时间戳 */
+  date_unix?: number
+
+  /** 评论日期 UTC RFC3339 字符串 */
+  date_utc?: string
+
   /** 是否折叠 */
   is_collapsed: boolean
 


### PR DESCRIPTION
Fix timezone-ambiguous comment timestamps by exposing timezone-safe timestamp fields and making the UI prefer them when rendering relative time.

Previously, the API returned `date` as a timezone-less string such as `2026-07-27 12:00:00`. Browsers parse that as local time, so users in different timezones could see newly created comments as “1 hour ago” or keep seeing “now” when the parsed time falls in the future.

Link to: https://github.com/ArtalkJS/Artalk/issues/1165

## Changes

- Add `date_unix` and `date_utc` to cooked comment/page API responses.
- Keep the existing `date` field for backward compatibility.
- Make the frontend prefer `date_unix` / `date_utc` before falling back to legacy `date`.
- Update comment sorting and time ticking to use the same timestamp-safe parser.
- Expose the new fields in email template data and Swagger docs.

## Compatibility

This is backward compatible:

- Existing `date` remains unchanged.
- Existing clients can continue using the old field.
- New clients can use `date_unix` or `date_utc` to avoid timezone ambiguity.
- No database schema migration is required.

---
> This PR was authored with the assistance of Codex.
